### PR TITLE
DWTA-149 Mongo fetch race condition

### DIFF
--- a/src/common/helpers/find-waste-inputs.js
+++ b/src/common/helpers/find-waste-inputs.js
@@ -1,0 +1,58 @@
+import { config } from '../../config.js'
+
+/**
+ * Finds waste inputs for the given wasteTrackingIdsAndRevisions in the given collections.
+ *
+ * This is done in a loop to ensure that all data has been persisted to the cluster before
+ * we try to fetch the data, otherwise the data could be fetched from a replica that
+ * hasn't been updated yet resulting in a data mismatch error being thrown.
+ *
+ * Most of the time the data should be fetched on the first try.
+ *
+ * The number of fetch attempts is set with an env var and has a default set in the
+ * config.
+ *
+ * @param {Number} requestWasteInputsCount - The number of waste inputs in the request
+ * @param {[Collection]} collections - The collections in which to find the waste inputs
+ * @param {[{ wasteTrackingId: Number, revision: Number }]} wasteTrackingIdsAndRevisions - The waste tracking ids and revisions that were previously saved
+ *
+ * @returns {Promise<Array>} The waste inputs
+ */
+export async function findWasteInputs(
+  requestWasteInputsCount,
+  collections,
+  wasteTrackingIdsAndRevisions
+) {
+  let mongoFetchAttempts = config.get('mongoFetchAttempts')
+  let wasteInputs = []
+
+  while (
+    mongoFetchAttempts > 0 &&
+    wasteInputs.length !== requestWasteInputsCount
+  ) {
+    mongoFetchAttempts--
+
+    for (const collection of collections) {
+      if (wasteInputs.length === 0) {
+        wasteInputs = await collection
+          .find({
+            $or: wasteTrackingIdsAndRevisions.map(
+              ({ wasteTrackingId, revision }) => ({
+                _id: wasteTrackingId,
+                revision
+              })
+            )
+          })
+          .toArray()
+      }
+    }
+  }
+
+  if (wasteInputs.length !== requestWasteInputsCount) {
+    throw new Error(
+      `Failed to find waste inputs: Number of waste inputs found is different to the request waste inputs: Expected '${requestWasteInputsCount}' but found '${wasteInputs.length}'`
+    )
+  }
+
+  return wasteInputs
+}

--- a/src/common/helpers/find-waste-inputs.test.js
+++ b/src/common/helpers/find-waste-inputs.test.js
@@ -1,0 +1,85 @@
+import { findWasteInputs } from './find-waste-inputs.js'
+
+describe('#findWasteInputs', () => {
+  const wasteTrackingIds = [{ wasteTrackingId: 1 }, { wasteTrackingId: 2 }]
+
+  it('should return the requested waste inputs on the first attempt', async () => {
+    const collection = {
+      find: jest.fn().mockReturnValue({
+        toArray: jest.fn().mockReturnValue([{}, {}])
+      })
+    }
+    const findSpy = jest.spyOn(collection, 'find')
+
+    const result = await findWasteInputs(2, [collection], wasteTrackingIds)
+
+    expect(result).toEqual([{}, {}])
+
+    expect(findSpy).toHaveBeenCalledTimes(1)
+  })
+
+  it('should return the requested waste inputs on the third attempt if not found in the previous attempts', async () => {
+    const collection = {
+      find: jest.fn().mockReturnValue({
+        toArray: jest
+          .fn()
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([{}, {}])
+      })
+    }
+    const findSpy = jest.spyOn(collection, 'find')
+
+    const result = await findWasteInputs(2, [collection], wasteTrackingIds)
+
+    expect(result).toEqual([{}, {}])
+
+    expect(findSpy).toHaveBeenCalledTimes(3)
+  })
+
+  it('should throw an error if no waste inputs were found', async () => {
+    const collection = {
+      find: jest.fn().mockReturnValue({
+        toArray: jest
+          .fn()
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+      })
+    }
+    const findSpy = jest.spyOn(collection, 'find')
+
+    await expect(
+      findWasteInputs(2, [collection], wasteTrackingIds)
+    ).rejects.toThrow(
+      "Failed to find waste inputs: Number of waste inputs found is different to the request waste inputs: Expected '2' but found '0'"
+    )
+
+    expect(findSpy).toHaveBeenCalledTimes(5)
+  })
+
+  it('should throw an error if less waste inputs than expected were found', async () => {
+    const collection = {
+      find: jest.fn().mockReturnValue({
+        toArray: jest
+          .fn()
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([])
+          .mockReturnValueOnce([{}])
+      })
+    }
+    const findSpy = jest.spyOn(collection, 'find')
+
+    await expect(
+      findWasteInputs(2, [collection], wasteTrackingIds)
+    ).rejects.toThrow(
+      "Failed to find waste inputs: Number of waste inputs found is different to the request waste inputs: Expected '2' but found '1'"
+    )
+
+    expect(findSpy).toHaveBeenCalledTimes(5)
+  })
+})

--- a/src/config.js
+++ b/src/config.js
@@ -174,6 +174,12 @@ const config = convict({
       default: '',
       env: 'SERVICE_AUTH_PASSWORD_WASTE_MOVEMENT_BACKEND'
     }
+  },
+  mongoFetchAttempts: {
+    doc: 'The number of attempts that will be made to fetch data from Mongo',
+    format: Number,
+    default: 5,
+    env: 'MONGO_FETCH_ATTEMPTS'
   }
 })
 

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -635,8 +635,6 @@ describe('Error Handler', () => {
       expect(response.statusCode).toBe(400)
       const responseBody = JSON.parse(response.payload)
 
-      console.dir({ responseBody }, { depth: null })
-
       const formatError = responseBody[0].validation.errors.find(
         (err) => err.key === '0' && err.errorType === 'NotProvided'
       )

--- a/src/services/movement-create-bulk.js
+++ b/src/services/movement-create-bulk.js
@@ -1,5 +1,6 @@
 import { AUDIT_LOGGER_TYPE } from '../common/constants/audit-logger.js'
 import { BULK_RESPONSE_STATUS } from '../common/constants/bulk-response-status.js'
+import { findWasteInputs } from '../common/helpers/find-waste-inputs.js'
 import { auditLogger } from '../common/helpers/logging/audit-logger.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
@@ -70,20 +71,14 @@ export async function createBulkWasteInput(db, mongoClient, wasteInputs) {
       }
     }
 
-    const createdWasteInputs = await wasteInputsCollection
-      .find({
-        $or: createdWasteTrackingIds.map((wasteTrackingId) => ({
-          _id: wasteTrackingId,
-          revision: 1
-        }))
-      })
-      .toArray()
-
-    if (createdWasteInputs.length !== wasteInputs.length) {
-      throw new Error(
-        `Failed to create waste inputs: Number of created waste inputs is different to the request waste inputs: Expected '${wasteInputs.length}' but created '${createdWasteInputs.length}'`
-      )
-    }
+    const createdWasteInputs = await findWasteInputs(
+      wasteInputs.length,
+      [wasteInputsCollection],
+      createdWasteTrackingIds.map((wasteTrackingId) => ({
+        wasteTrackingId,
+        revision: 1
+      }))
+    )
 
     sendAuditLogs(createdWasteInputs)
 

--- a/src/services/movement-create-bulk.test.js
+++ b/src/services/movement-create-bulk.test.js
@@ -207,7 +207,7 @@ describe('#createBulkWasteInput', () => {
     await expect(() =>
       createBulkWasteInput(dbMock, mongoClient, wasteInputs)
     ).rejects.toThrow(
-      `Failed to create waste inputs: Number of created waste inputs is different to the request waste inputs: Expected '2' but created '0'`
+      `Failed to find waste inputs: Number of waste inputs found is different to the request waste inputs: Expected '2' but found '0'`
     )
 
     expect(auditSpy).not.toHaveBeenCalled()

--- a/src/services/movement-create.js
+++ b/src/services/movement-create.js
@@ -1,6 +1,7 @@
 import { createLogger } from '../common/helpers/logging/logger.js'
 import { AUDIT_LOGGER_TYPE } from '../common/constants/audit-logger.js'
 import { auditLogger } from '../common/helpers/logging/audit-logger.js'
+import { findWasteInputs } from '../common/helpers/find-waste-inputs.js'
 
 const logger = createLogger()
 
@@ -11,14 +12,15 @@ export async function createWasteInput(db, wasteInput, traceId) {
     const now = new Date()
     wasteInput.createdAt = now
     wasteInput.lastUpdatedAt = now
-    const collection = db.collection('waste-inputs')
-    const result = await collection.insertOne(wasteInput)
+    const wasteInputsCollection = db.collection('waste-inputs')
+    const result = await wasteInputsCollection.insertOne(wasteInput)
     const wasteTrackingId = result?.insertedId
 
-    const createdWasteInput = await collection.findOne({
-      _id: wasteTrackingId,
-      revision: 1
-    })
+    const [createdWasteInput] = await findWasteInputs(
+      1,
+      [wasteInputsCollection],
+      [{ wasteTrackingId, revision: 1 }]
+    )
 
     auditLogger({
       type: AUDIT_LOGGER_TYPE.MOVEMENT_CREATED,

--- a/src/services/movement-update-bulk.js
+++ b/src/services/movement-update-bulk.js
@@ -2,6 +2,7 @@ import { createLogger } from '../common/helpers/logging/logger.js'
 import { createHistoryEntry } from '../common/helpers/create-history-entry.js'
 import { auditLogger } from '../common/helpers/logging/audit-logger.js'
 import { AUDIT_LOGGER_TYPE } from '../common/constants/audit-logger.js'
+import { findWasteInputs } from '../common/helpers/find-waste-inputs.js'
 
 const logger = createLogger()
 
@@ -11,14 +12,14 @@ async function sendAuditLogs(
   existingWasteInputs,
   traceId
 ) {
-  const updatedWasteInputs = await wasteInputsCollection
-    .find({
-      $or: payload.map((item, index) => ({
-        _id: item.wasteTrackingId,
-        revision: existingWasteInputs[index].revision + 1
-      }))
-    })
-    .toArray()
+  const updatedWasteInputs = await findWasteInputs(
+    payload.length,
+    [wasteInputsCollection],
+    payload.map((item, index) => ({
+      wasteTrackingId: item.wasteTrackingId,
+      revision: existingWasteInputs[index].revision + 1
+    }))
+  )
 
   updatedWasteInputs.forEach((wasteInput) => {
     auditLogger({

--- a/src/services/movement-update.js
+++ b/src/services/movement-update.js
@@ -5,6 +5,7 @@ import { config } from '../config.js'
 import { AUDIT_LOGGER_TYPE } from '../common/constants/audit-logger.js'
 import { auditLogger } from '../common/helpers/logging/audit-logger.js'
 import { createHistoryEntry } from '../common/helpers/create-history-entry.js'
+import { findWasteInputs } from '../common/helpers/find-waste-inputs.js'
 
 const logger = createLogger()
 
@@ -143,25 +144,16 @@ export async function updateWasteInput(
  * @param {Number} wasteTrackingId - The request waste tracking id
  * @param {Number} existingRevision - The revision of the updated record
  * @param {String} traceId - The unique id of the request
- * @param {Object} session - The MongoDB session for the transaction
  */
 async function createAuditLog(
   collections,
   wasteTrackingId,
   existingRevision,
-  traceId,
-  session
+  traceId
 ) {
-  let updatedWasteInput
-
-  for (const collection of collections) {
-    if (!updatedWasteInput) {
-      updatedWasteInput = await collection.findOne(
-        { _id: wasteTrackingId, revision: existingRevision + 1 },
-        { session }
-      )
-    }
-  }
+  const [updatedWasteInput] = await findWasteInputs(1, collections, [
+    { wasteTrackingId, revision: existingRevision + 1 }
+  ])
 
   auditLogger({
     type: AUDIT_LOGGER_TYPE.MOVEMENT_UPDATED,


### PR DESCRIPTION
Ticket [DWTA-149](https://eaflood.atlassian.net/browse/DWTA-149)

After saving new or updated data we immediately fetch that data to use to send to the Audit Log so we can verify that the data exists (for newly created data) and that we send an exact copy of the data that we've stored in Mongo to the Audit Log. 

This occasionally creates a race condition where we try to read the data from a cluster replica that's not been written to yet and the new data is not returned.

This change addresses that by creating a `findWasteInputs()` helper function to fetch the data from Mongo in a loop to give the cluster a chance to fully update before we throw the error indicating a data mismatch. This helper function is implemented for create/update single requests (External API) and create/update bulk requests.

The number of loop iterations is configurable with a `MONGO_FETCH_ATTEMPTS` env var and defaults to 5. 

If the data is found before all loop iterations have completed then the loop exits and this is an occasional race condition so the loop should only require one iteration for most requests so this should not have much impact on performance.

[DWTA-149]: https://eaflood.atlassian.net/browse/DWTA-149?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ