### PR TITLE
DWTA-61 and DWTA-85 Add Metric For Bulk Receipt Movements

### DIFF
--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -14,6 +14,7 @@ import {
 import { bulkReceiveMovementRequestSchema } from '../schemas/bulk-receipt.js'
 import Joi from 'joi'
 import { generateAllValidationWarnings } from '../common/helpers/validation-warnings/validation-warnings.js'
+import { metricsCounter } from '../common/helpers/metrics.js'
 
 const createBulkReceiptMovement = {
   method: 'POST',
@@ -103,6 +104,12 @@ const createBulkReceiptMovement = {
           createBulkWasteInput(request.db, request.mongoClient, wasteInputs),
         BACKOFF_OPTIONS
       )
+
+      if (createdMovements.status === BULK_RESPONSE_STATUS.MOVEMENTS_CREATED) {
+        createdMovements.wasteTrackingIds.forEach(() =>
+          metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
+        )
+      }
 
       const response = generateResponseWithValidationWarnings(
         createdMovements.wasteTrackingIds,

--- a/src/routes/create-bulk-receipt-movement.test.js
+++ b/src/routes/create-bulk-receipt-movement.test.js
@@ -11,6 +11,23 @@ import { createBulkReceiptMovement } from './create-bulk-receipt-movement.js'
 import { BULK_RESPONSE_STATUS } from '../common/constants/bulk-response-status.js'
 import { createBulkMovementRequest } from '../test/utils/createBulkMovementRequest.js'
 import * as batch from '../common/helpers/batch.js'
+import * as metricsCounter from '../common/helpers/metrics.js'
+
+const assertMetricsCounterWasCalled = (metricsCounterSpy) => {
+  expect(metricsCounterSpy).toHaveBeenCalledTimes(2)
+  expect(metricsCounterSpy).toHaveBeenNthCalledWith(
+    1,
+    'receipts.received.bulk',
+    1,
+    { endpointType: 'post' }
+  )
+  expect(metricsCounterSpy).toHaveBeenNthCalledWith(
+    2,
+    'receipts.received.bulk',
+    1,
+    { endpointType: 'post' }
+  )
+}
 
 jest.mock('../common/constants/exponential-backoff.js', () => ({
   BACKOFF_OPTIONS: {
@@ -111,6 +128,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       movementCreateBulk,
       'createBulkWasteInput'
     )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 
     movementCreateBulk.createBulkWasteInput
       .mockImplementationOnce(() => {
@@ -163,6 +181,8 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     }
 
     expect(createBulkWasteInputSpy).toHaveBeenCalledTimes(3)
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('creates multiple waste inputs with a waste input containing a warning', async () => {
@@ -172,6 +192,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       movementCreateBulk,
       'createBulkWasteInput'
     )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 
     movementCreateBulk.createBulkWasteInput
       .mockImplementationOnce(() => {
@@ -236,9 +257,13 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     }
 
     expect(createBulkWasteInputSpy).toHaveBeenCalledTimes(3)
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should return existing waste tracking ids when provided with a bulk id which has already been used by the POST endpoint in the waste-inputs collection', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     await server.inject({
       method: 'POST',
       url: `/bulk/${bulkId}/movements/receive`,
@@ -265,9 +290,15 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
         { wasteTrackingId: '26NWSIXF' }
       ]
     })
+
+    // Expect metricsCounter to be called twice as the endpoint is called twice above, metricsCounter
+    // should only called the first time
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should return existing waste tracking ids when provided with a bulk id which has already been used by the POST endpoint in the waste-inputs-history collection', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     await server.inject({
       method: 'POST',
       url: `/bulk/${bulkId}/movements/receive`,
@@ -294,9 +325,15 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
         { wasteTrackingId: '26NWSIXF' }
       ]
     })
+
+    // Expect metricsCounter to be called twice as the endpoint is called twice above, metricsCounter
+    // should only called the first time
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should create new waste inputs when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs collection', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     await server.inject({
       method: 'POST',
       url: `/bulk/${bulkId}/movements/receive`,
@@ -324,9 +361,13 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
         { wasteTrackingId: '26NWSIXF' }
       ]
     })
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should create new waste inputs when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs-history collection', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     await server.inject({
       method: 'POST',
       url: `/bulk/${bulkId}/movements/receive`,
@@ -354,6 +395,8 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
         { wasteTrackingId: '26NWSIXF' }
       ]
     })
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('can handle multiple concurrent requests with the same bulkId', async () => {
@@ -389,6 +432,8 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
   })
 
   it('rejects when Mongo throws a schema validation error', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     const { statusCode, result } = await server.inject({
       method: 'POST',
       url: `/bulk/${bulkId}/movements/receive`,
@@ -402,6 +447,8 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       message:
         '[{"failingDocumentId":"26S8EYDJ","details":{"operatorName":"$jsonSchema","schemaRulesNotSatisfied":[{"operatorName":"properties","propertiesNotSatisfied":[{"propertyName":"traceId","details":[{"operatorName":"bsonType","specifiedAs":{"bsonType":"string"},"reason":"type did not match","consideredValue":null,"consideredType":"null"}]}]}]}}]'
     })
+
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 
   it('handles error when creating multiple waste inputs fails', async () => {
@@ -409,6 +456,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       movementCreateBulk,
       'createBulkWasteInput'
     )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 
     movementCreateBulk.createBulkWasteInput.mockRejectedValue(
       new Error(errorMessage)
@@ -431,6 +479,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     })
 
     expect(createBulkWasteInputSpy).toHaveBeenCalledTimes(3)
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 
   it("throws an error when the number of waste tracking ids generated doesn't match the number of movements in the payload", async () => {
@@ -440,6 +489,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       movementCreateBulk,
       'createBulkWasteInput'
     )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 
     const { statusCode, result } = await server.inject({
       method: 'POST',
@@ -459,5 +509,6 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     })
 
     expect(createBulkWasteInputSpy).toHaveBeenCalledTimes(0)
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 })

--- a/src/routes/update-bulk-receipt-movement.js
+++ b/src/routes/update-bulk-receipt-movement.js
@@ -10,6 +10,7 @@ import {
 } from '../common/helpers/bulk-route-helpers.js'
 import { bulkUpdateMovementRequestSchema } from '../schemas/bulk-receipt.js'
 import { getOrganisationValidationError } from '../common/helpers/validate-organisation.js'
+import { metricsCounter } from '../common/helpers/metrics.js'
 
 async function findWithHistoryFallback(
   wasteInputsCollection,
@@ -191,6 +192,10 @@ const updateBulkReceiptMovement = {
       if (!movements) {
         return noMovementsUpdatedResponse(h, payload)
       }
+
+      movements.forEach(() =>
+        metricsCounter('receipts.received.bulk', 1, { endpointType: 'put' })
+      )
 
       return h
         .response({

--- a/src/routes/update-bulk-receipt-movement.test.js
+++ b/src/routes/update-bulk-receipt-movement.test.js
@@ -18,6 +18,23 @@ import {
 import { BULK_RESPONSE_STATUS } from '../common/constants/bulk-response-status.js'
 import { config } from '../config.js'
 import { createBulkMovementRequest } from '../test/utils/createBulkMovementRequest.js'
+import * as metricsCounter from '../common/helpers/metrics.js'
+
+const assertMetricsCounterWasCalled = (metricsCounterSpy) => {
+  expect(metricsCounterSpy).toHaveBeenCalledTimes(2)
+  expect(metricsCounterSpy).toHaveBeenNthCalledWith(
+    1,
+    'receipts.received.bulk',
+    1,
+    { endpointType: 'put' }
+  )
+  expect(metricsCounterSpy).toHaveBeenNthCalledWith(
+    2,
+    'receipts.received.bulk',
+    1,
+    { endpointType: 'put' }
+  )
+}
 
 jest.mock('../common/constants/exponential-backoff.js', () => ({
   BACKOFF_OPTIONS: {
@@ -124,6 +141,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       movementUpdateBulk,
       'updateBulkWasteInput'
     )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 
     movementUpdateBulk.updateBulkWasteInput
       .mockImplementationOnce(() => {
@@ -153,9 +171,13 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     }
 
     expect(updateBulkWasteInputSpy).toHaveBeenCalledTimes(3)
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should return NO_MOVEMENTS_UPDATED when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs collection', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     // Update the seed data to have revision > 1 with the update bulkId
     await wasteInputsCollection.updateMany(
       {},
@@ -176,9 +198,13 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       status: BULK_RESPONSE_STATUS.NO_MOVEMENTS_UPDATED,
       movements: [{}, {}]
     })
+
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 
   it('should return NO_MOVEMENTS_UPDATED when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs-history collection', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     await wasteInputsHistoryCollection.insertMany([
       {
         wasteTrackingId: '26E4C7Z2',
@@ -214,9 +240,13 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       status: BULK_RESPONSE_STATUS.NO_MOVEMENTS_UPDATED,
       movements: [{}, {}]
     })
+
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 
   it('should proceed with update when bulkId exists with revision 1 only (POST endpoint bulkId)', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     // Seed data already has revision: 1 with createBulkId
     // Using createBulkId as the PUT bulkId - since all matches have revision: 1,
     // the idempotency check for revision > 1 should NOT trigger
@@ -234,6 +264,8 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       status: BULK_RESPONSE_STATUS.MOVEMENTS_UPDATED,
       movements: [{}, {}]
     })
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should return 400 when submittingOrganisation does not match and existing record has no submittingOrganisation', async () => {
@@ -320,6 +352,8 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
   it('should succeed when apiCode org matches the original record', async () => {
     config.set('orgApiCodes', base64EncodedOrgApiCodes)
 
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     const apiCodeItem = createBulkMovementRequest({
       wasteTrackingId: '26E4C7Z2',
       apiCode: apiCode1
@@ -342,6 +376,8 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
 
     expect(statusCode).toEqual(HTTP_STATUS_CODES.OK)
     expect(result.status).toEqual(BULK_RESPONSE_STATUS.MOVEMENTS_UPDATED)
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
   it('should return 400 when apiCode org does not match the original record', async () => {
@@ -386,6 +422,8 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
   })
 
   it('rejects when Mongo throws a schema validation error', async () => {
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
     const { statusCode, result } = await server.inject({
       method: 'PUT',
       url: `/bulk/${updateBulkId}/movements/receive`,
@@ -399,6 +437,8 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       message:
         '[{"failingDocumentId":"26E4C7Z2","details":{"operatorName":"$jsonSchema","schemaRulesNotSatisfied":[{"operatorName":"properties","propertiesNotSatisfied":[{"propertyName":"traceId","details":[{"operatorName":"bsonType","specifiedAs":{"bsonType":"string"},"reason":"type did not match","consideredValue":null,"consideredType":"null"}]}]}]}}]'
     })
+
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 
   it('handles error when updating multiple waste inputs fails', async () => {
@@ -406,6 +446,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       movementUpdateBulk,
       'updateBulkWasteInput'
     )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 
     movementUpdateBulk.updateBulkWasteInput.mockRejectedValue(
       new Error(errorMessage)
@@ -428,6 +469,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     })
 
     expect(updateBulkWasteInputSpy).toHaveBeenCalledTimes(3)
+    expect(metricsCounterSpy).not.toHaveBeenCalled()
   })
 
   it('should return 400 when payload is an empty array', async () => {


### PR DESCRIPTION
Ticket [DWTA-61](https://eaflood.atlassian.net/browse/DWTA-61)
Ticket [DWTA-85](https://eaflood.atlassian.net/browse/DWTA-85)

This PR uses `metricsCounter` in the Bulk Upload `POST` and `PUT` routes to collect metrics for each movement in the request. Metrics are only collected when the movements are initially created/updated and not for subsequent retries of the same request.

[DWTA-61]: https://eaflood.atlassian.net/browse/DWTA-61?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[DWTA-85]: https://eaflood.atlassian.net/browse/DWTA-85?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ