### PR TITLE
DWTA-150 Track Bulk Upload Waste Receivers

### DIFF
--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -106,13 +106,13 @@ const createBulkReceiptMovement = {
       )
 
       if (createdMovements.status === BULK_RESPONSE_STATUS.MOVEMENTS_CREATED) {
-        createdMovements.wasteTrackingIds.forEach(() =>
+        createdMovements.wasteInputs.forEach(() =>
           metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
         )
       }
 
       const response = generateResponseWithValidationWarnings(
-        createdMovements.wasteTrackingIds,
+        createdMovements.wasteInputs,
         payload
       )
 
@@ -147,23 +147,21 @@ function createWasteInputs(payload, wasteTrackingIds, traceId, bulkId) {
   })
 }
 
-function generateResponseWithValidationWarnings(
-  createdWasteTrackingIds,
-  payload
-) {
-  return createdWasteTrackingIds.map((item, index) => {
+function generateResponseWithValidationWarnings(wasteInputs, payload) {
+  return wasteInputs.map(({ wasteTrackingId }, index) => {
+    const response = { wasteTrackingId }
     const warnings = generateAllValidationWarnings(
       payload[index],
-      item.wasteTrackingId
+      wasteTrackingId
     )
 
     if (warnings.length > 0) {
-      item.validation = {
+      response.validation = {
         warnings
       }
     }
 
-    return item
+    return response
   })
 }
 

--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -105,14 +105,7 @@ const createBulkReceiptMovement = {
         BACKOFF_OPTIONS
       )
 
-      if (createdMovements.status === BULK_RESPONSE_STATUS.MOVEMENTS_CREATED) {
-        createdMovements.wasteInputs.forEach((wasteInput) => {
-          metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
-          metricsCounter('receiver.orgId.bulk', 1, {
-            orgId: wasteInput.submittingOrganisation.defraCustomerOrganisationId
-          })
-        })
-      }
+      collectMetrics(createdMovements)
 
       const response = generateResponseWithValidationWarnings(
         createdMovements.wasteInputs,
@@ -166,6 +159,26 @@ function generateResponseWithValidationWarnings(wasteInputs, payload) {
 
     return response
   })
+}
+
+/**
+ * Collects metrics for the created movements
+ *
+ * @param {Object} createdMovements - The created movements
+ * @param {String} createdMovements.status - The status of the created movements
+ * @param {Object} createdMovements.wasteInputs - The created waste inputs
+ *
+ * @returns {void}
+ */
+function collectMetrics(createdMovements) {
+  if (createdMovements.status === BULK_RESPONSE_STATUS.MOVEMENTS_CREATED) {
+    createdMovements.wasteInputs.forEach((wasteInput) => {
+      metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
+      metricsCounter('receiver.orgId.bulk', 1, {
+        orgId: wasteInput.submittingOrganisation.defraCustomerOrganisationId
+      })
+    })
+  }
 }
 
 export { createBulkReceiptMovement }

--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -106,9 +106,12 @@ const createBulkReceiptMovement = {
       )
 
       if (createdMovements.status === BULK_RESPONSE_STATUS.MOVEMENTS_CREATED) {
-        createdMovements.wasteInputs.forEach(() =>
+        createdMovements.wasteInputs.forEach((wasteInput) => {
           metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
-        )
+          metricsCounter('receiver.orgId.bulk', 1, {
+            orgId: wasteInput.submittingOrganisation.defraCustomerOrganisationId
+          })
+        })
       }
 
       const response = generateResponseWithValidationWarnings(

--- a/src/routes/create-bulk-receipt-movement.test.js
+++ b/src/routes/create-bulk-receipt-movement.test.js
@@ -14,7 +14,7 @@ import * as batch from '../common/helpers/batch.js'
 import * as metricsCounter from '../common/helpers/metrics.js'
 
 const assertMetricsCounterWasCalled = (metricsCounterSpy) => {
-  expect(metricsCounterSpy).toHaveBeenCalledTimes(2)
+  expect(metricsCounterSpy).toHaveBeenCalledTimes(4)
   expect(metricsCounterSpy).toHaveBeenNthCalledWith(
     1,
     'receipts.received.bulk',
@@ -23,9 +23,26 @@ const assertMetricsCounterWasCalled = (metricsCounterSpy) => {
   )
   expect(metricsCounterSpy).toHaveBeenNthCalledWith(
     2,
+    'receiver.orgId.bulk',
+    1,
+    {
+      orgId: 'fd98d4ef34e33b34fc8fad03f8c385'
+    }
+  )
+  expect(metricsCounterSpy).toHaveBeenNthCalledWith(
+    3,
     'receipts.received.bulk',
     1,
     { endpointType: 'post' }
+  )
+
+  expect(metricsCounterSpy).toHaveBeenNthCalledWith(
+    4,
+    'receiver.orgId.bulk',
+    1,
+    {
+      orgId: 'fd98d4ef34e33b34fc8fad03f8c385'
+    }
   )
 }
 

--- a/src/services/movement-create-bulk.js
+++ b/src/services/movement-create-bulk.js
@@ -65,9 +65,7 @@ export async function createBulkWasteInput(db, mongoClient, wasteInputs) {
     if (existingWasteInputs.length > 0) {
       return {
         status: BULK_RESPONSE_STATUS.MOVEMENTS_NOT_CREATED,
-        wasteTrackingIds: existingWasteInputs.map(({ wasteTrackingId }) => ({
-          wasteTrackingId
-        }))
+        wasteInputs: existingWasteInputs
       }
     }
 
@@ -84,9 +82,7 @@ export async function createBulkWasteInput(db, mongoClient, wasteInputs) {
 
     return {
       status: BULK_RESPONSE_STATUS.MOVEMENTS_CREATED,
-      wasteTrackingIds: createdWasteInputs.map(({ wasteTrackingId }) => ({
-        wasteTrackingId
-      }))
+      wasteInputs: createdWasteInputs
     }
   } catch (error) {
     logger.error({ error }, 'Failed to create waste inputs')

--- a/src/services/movement-create-bulk.test.js
+++ b/src/services/movement-create-bulk.test.js
@@ -57,6 +57,7 @@ describe('#createBulkWasteInput', () => {
   beforeEach(async () => {
     wasteInputs = [
       {
+        _id: '26E4C7Z2',
         wasteTrackingId: '26E4C7Z2',
         receipt: {},
         createdAt: new Date(),
@@ -67,6 +68,7 @@ describe('#createBulkWasteInput', () => {
         revision: 1
       },
       {
+        _id: '266XHTDL',
         wasteTrackingId: '266XHTDL',
         receipt: {},
         createdAt: new Date(),
@@ -92,10 +94,7 @@ describe('#createBulkWasteInput', () => {
 
     expect(result).toEqual({
       status: BULK_RESPONSE_STATUS.MOVEMENTS_CREATED,
-      wasteTrackingIds: [
-        { wasteTrackingId: '26E4C7Z2' },
-        { wasteTrackingId: '266XHTDL' }
-      ]
+      wasteInputs
     })
 
     const updatedWasteInput1 = await wasteInputsCollection.findOne({
@@ -136,10 +135,7 @@ describe('#createBulkWasteInput', () => {
 
     expect(result).toEqual({
       status: BULK_RESPONSE_STATUS.MOVEMENTS_CREATED,
-      wasteTrackingIds: [
-        { wasteTrackingId: '26E4C7Z2' },
-        { wasteTrackingId: '266XHTDL' }
-      ]
+      wasteInputs
     })
 
     const updatedWasteInput1 = await wasteInputsCollection.findOne({
@@ -166,10 +162,7 @@ describe('#createBulkWasteInput', () => {
 
     expect(result).toEqual({
       status: BULK_RESPONSE_STATUS.MOVEMENTS_NOT_CREATED,
-      wasteTrackingIds: [
-        { wasteTrackingId: '26E4C7Z2' },
-        { wasteTrackingId: '266XHTDL' }
-      ]
+      wasteInputs
     })
 
     expect(auditSpy).not.toHaveBeenCalled()


### PR DESCRIPTION
Ticket [DWTA-150](https://eaflood.atlassian.net/browse/DWTA-150)

Currently we're collecting metrics for the number of waste receivers using the External API (`receiver.orgId`) and we need to do the same for those using the Bulk Upload. This change does that by:

**Commit 1** - Refactor `createBulkWasteInput` to return a list of waste input objects rather than a list of waste tarcking ids so that additional properties from the waste input object can be used in the route.

**Commit 2** - Add metrics collection for `receiver.orgId.bulk` using `defraCustomerOrganisationId` from the waste input object exposed in the first commit. By adding a suffix of `.bulk` to the metrics key, it should enable us to visualise receivers using the API and Bulk Upload as a combined total and also as separate totals

**Commit 3** - Refactor metrics collection in the route into a separate function.

[DWTA-150]: https://eaflood.atlassian.net/browse/DWTA-150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ