### PR TITLE
DWTA-176 Possible bug in the Mongo schema validation

### DIFF
--- a/src/schemas/waste-input.js
+++ b/src/schemas/waste-input.js
@@ -107,7 +107,7 @@ export const wasteInputSchema = {
               bsonType: 'string'
             },
             reasonForNoConsignmentCode: {
-              bsonType: 'string'
+              bsonType: ['string', 'null']
             },
             yourUniqueReference: {
               bsonType: 'string'


### PR DESCRIPTION
 ### Description
  Ticket [DWTA-176](https://eaflood.atlassian.net/browse/DWTA-176)

  The Mongo `$jsonSchema` rejects a `null` value for `reasonForNoConsignmentCode` whereas
   the API-level Joi validation accepts it. This caused ETL ingestion failures when
  clients supplied `hazardousWasteConsignmentCode` alongside an explicit `null` for
  `reasonForNoConsignmentCode`.

  - Widened `bsonType` from `'string'` to `['string', 'null']` so the Mongo schema
  matches API behaviour.


[DWTA-176]: https://eaflood.atlassian.net/browse/DWTA-176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ