### PR TITLE
DWTA-157 Add missing Backend service schema unit tests

### DIFF
--- a/src/schemas/date-time-received.test.js
+++ b/src/schemas/date-time-received.test.js
@@ -1,0 +1,42 @@
+import { receiveMovementRequestSchema } from './receipt.js'
+import { createMovementRequest } from '../test/utils/createMovementRequest.js'
+import { v4 as uuidv4 } from 'uuid'
+
+describe('Create Receipt Movement - Date and Time Received Validation', () => {
+  describe('Schema Validation Tests for dateTimeReceived', () => {
+    it('should accept a valid ISO date-time for dateTimeReceived', () => {
+      const payload = {
+        ...createMovementRequest(),
+        dateTimeReceived: '2025-08-29T15:24:00Z'
+      }
+
+      const { error } = receiveMovementRequestSchema.validate(payload)
+      expect(error).toBeUndefined()
+    })
+
+    it('should reject an invalid date-time for dateTimeReceived', () => {
+      const payload = {
+        ...createMovementRequest(),
+        // Invalid ISO date-time
+        dateTimeReceived: 'not-a-date'
+      }
+
+      const { error } = receiveMovementRequestSchema.validate(payload)
+      expect(error).toBeDefined()
+      // Joi message for iso constraint typically contains 'must be in iso format'
+      expect(error.details[0].message.toLowerCase()).toBe(
+        '"datetimereceived" must be in iso 8601 date format'
+      )
+    })
+
+    it('should reject when receipt is provided without dateTimeReceived', () => {
+      const payload = {
+        apiCode: uuidv4()
+      }
+
+      const { error } = receiveMovementRequestSchema.validate(payload)
+      expect(error).toBeDefined()
+      expect(error.details[0].message).toBe('"dateTimeReceived" is required')
+    })
+  })
+})

--- a/src/schemas/disposal-recovery-codes.test.js
+++ b/src/schemas/disposal-recovery-codes.test.js
@@ -1,0 +1,159 @@
+import { receiveMovementRequestSchema } from './receipt.js'
+import { DISPOSAL_OR_RECOVERY_CODES } from '../common/constants/treatment-codes.js'
+import { createMovementRequest } from '../test/utils/createMovementRequest.js'
+
+describe('Create Receipt Movement - Disposal/Recovery Code Validation', () => {
+  function createPayload(disposalOrRecoveryCodes) {
+    const baseRequest = createMovementRequest()
+
+    // If disposalOrRecoveryCodes provided, add them to the first wasteItem
+    if (disposalOrRecoveryCodes) {
+      return {
+        ...baseRequest,
+        wasteItems: [
+          {
+            ...baseRequest.wasteItems[0],
+            disposalOrRecoveryCodes:
+              disposalOrRecoveryCodes.disposalOrRecoveryCodes
+          }
+        ]
+      }
+    }
+
+    return baseRequest
+  }
+
+  describe('Schema Validation Tests', () => {
+    describe('Valid Disposal/Recovery Codes', () => {
+      DISPOSAL_OR_RECOVERY_CODES.forEach((code) => {
+        it(`should accept valid code: ${code}`, () => {
+          const validPayload = createPayload({
+            disposalOrRecoveryCodes: [
+              {
+                code,
+                weight: {
+                  metric: 'Tonnes',
+                  amount: 0.1,
+                  isEstimate: false
+                }
+              }
+            ]
+          })
+
+          const { error } = receiveMovementRequestSchema.validate(validPayload)
+          expect(error).toBeUndefined()
+        })
+      })
+
+      it('should accept multiple valid codes', () => {
+        const validPayload = createPayload({
+          disposalOrRecoveryCodes: [
+            {
+              code: 'R1',
+              weight: {
+                metric: 'Tonnes',
+                amount: 0.1,
+                isEstimate: false
+              }
+            },
+            {
+              code: 'D10',
+              weight: {
+                metric: 'Tonnes',
+                amount: 0.0505,
+                isEstimate: false
+              }
+            },
+            {
+              code: 'R3',
+              weight: {
+                metric: 'Tonnes',
+                amount: 0.02,
+                isEstimate: false
+              }
+            }
+          ]
+        })
+
+        const { error } = receiveMovementRequestSchema.validate(validPayload)
+        expect(error).toBeUndefined()
+      })
+    })
+
+    describe('Invalid Disposal/Recovery Codes', () => {
+      const invalidCodes = ['X99', 'R99', 'D99', 'ABC', '123', 'R0', 'D0']
+
+      invalidCodes.forEach((code) => {
+        it(`should reject invalid code: ${code}`, () => {
+          const invalidPayload = createPayload({
+            disposalOrRecoveryCodes: [
+              {
+                code,
+                weight: {
+                  metric: 'Tonnes',
+                  amount: 0.1,
+                  isEstimate: false
+                }
+              }
+            ]
+          })
+
+          const { error } =
+            receiveMovementRequestSchema.validate(invalidPayload)
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toContain('must be one of')
+        })
+      })
+    })
+
+    describe('Missing Quantity', () => {
+      it('should reject code without quantity', () => {
+        const invalidPayload = createPayload({
+          disposalOrRecoveryCodes: [
+            {
+              code: 'R1'
+              // No quantity specified
+            }
+          ]
+        })
+
+        const { error } = receiveMovementRequestSchema.validate(invalidPayload)
+        expect(error).toBeDefined()
+        expect(error.details[0].message).toContain(
+          '"wasteItems[0].disposalOrRecoveryCodes[0].weight" is required'
+        )
+      })
+    })
+
+    describe('Incomplete Quantity', () => {
+      it('should reject quantity without required fields', () => {
+        const invalidPayload = createPayload({
+          disposalOrRecoveryCodes: [
+            {
+              code: 'R1',
+              weight: {
+                metric: 'Tonnes'
+                // Missing amount and isEstimate
+              }
+            }
+          ]
+        })
+
+        const { error } = receiveMovementRequestSchema.validate(invalidPayload)
+        expect(error).toBeDefined()
+        expect(error.details.length).toBeGreaterThan(0)
+      })
+    })
+
+    describe('Optional Disposal/Recovery Codes', () => {
+      it('should accept submission without disposal/recovery codes', () => {
+        const validPayload = createPayload({
+          // No disposalOrRecoveryCodes specified
+        })
+
+        const { error } = receiveMovementRequestSchema.validate(validPayload)
+        expect(error).toBeUndefined()
+      })
+    })
+  })
+})

--- a/src/schemas/means-of-transport.test.js
+++ b/src/schemas/means-of-transport.test.js
@@ -1,0 +1,73 @@
+import { receiveMovementRequestSchema } from './receipt.js'
+import { MEANS_OF_TRANSPORT } from '../common/constants/means-of-transport.js'
+import { createMovementRequest } from '../test/utils/createMovementRequest.js'
+
+describe('Create Receipt Movement - Means of Transport Validation', () => {
+  describe('Schema Validation Tests', () => {
+    describe('Valid Means of Transport', () => {
+      MEANS_OF_TRANSPORT.forEach((meansOfTransport) => {
+        it(`should accept valid means of transport: ${meansOfTransport}`, () => {
+          const validPayload = createMovementRequest({
+            carrier: {
+              registrationNumber: 'CBDU123456',
+              organisationName: 'Test Carrier',
+              meansOfTransport,
+              vehicleRegistration:
+                meansOfTransport !== 'Road' ? undefined : 'ABC123'
+            }
+          })
+
+          const { error } = receiveMovementRequestSchema.validate(validPayload)
+          expect(error).toBeUndefined()
+        })
+      })
+    })
+
+    describe('Invalid Means of Transport', () => {
+      const invalidMeansOfTransport = [
+        'Bike',
+        'Walking',
+        'Teleport',
+        'Invalid',
+        '123'
+      ]
+
+      invalidMeansOfTransport.forEach((meansOfTransport) => {
+        it(`should reject invalid means of transport: ${meansOfTransport}`, () => {
+          const invalidPayload = {
+            ...createMovementRequest({
+              dateTimeReceived: new Date().toISOString()
+            }),
+            carrier: {
+              registrationNumber: 'CBDU123456',
+              organisationName: 'Test Carrier',
+              meansOfTransport
+            }
+          }
+
+          const { error } =
+            receiveMovementRequestSchema.validate(invalidPayload)
+          expect(error).toBeDefined()
+          expect(error.details[0].message).toContain('must be one of')
+        })
+      })
+
+      it('should reject submission without means of transport', () => {
+        const invalidPayload = {
+          ...createMovementRequest(),
+          carrier: {
+            registrationNumber: 'CBDU123456',
+            organisationName: 'Test Carrier',
+            meansOfTransport: undefined
+          }
+        }
+
+        const { error } = receiveMovementRequestSchema.validate(invalidPayload)
+        expect(error).toBeDefined()
+        expect(error.details[0].message).toBe(
+          '"carrier.meansOfTransport" is required'
+        )
+      })
+    })
+  })
+})


### PR DESCRIPTION
 ### Description
  Ticket [DWTA-157](https://eaflood.atlassian.net/browse/DWTA-157)

This pull request introduces the following changes:

- Adds the missing unit test files for Backend service schema validation:
  - `date-time-received.test.js`
  - `disposal-recovery-codes.test.js`
  - `means-of-transport.test.js`
- Ports these files from the External API codebase to ensure schema validation is sufficiently covered in the Backend service, consistent with the existing pattern for other shared schema tests.

[DWTA-157]: https://eaflood.atlassian.net/browse/DWTA-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ