### PR TITLE
DWTA-162 Add warnings to the Update Bulk Receipt Movement response

### DIFF
--- a/src/common/helpers/bulk-route-helpers.js
+++ b/src/common/helpers/bulk-route-helpers.js
@@ -1,6 +1,7 @@
 import Joi from 'joi'
 import { HTTP_STATUS_CODES } from '../constants/http-status-codes.js'
 import { MongoServerError } from 'mongodb'
+import { generateAllValidationWarnings } from './validation-warnings/validation-warnings.js'
 
 const badRequestResponse = {
   [HTTP_STATUS_CODES.BAD_REQUEST]: {
@@ -56,4 +57,22 @@ function handleRouteError(h, error) {
     .code(statusCode)
 }
 
-export { badRequestResponse, handleRouteError }
+function generateResponseWithValidationWarnings(payload, wasteTrackingIds) {
+  return payload.map((item, index) => {
+    const wasteTrackingId = wasteTrackingIds?.[index] ?? item.wasteTrackingId
+    const response = wasteTrackingIds ? { wasteTrackingId } : {}
+    const warnings = generateAllValidationWarnings(item, wasteTrackingId)
+
+    if (warnings.length > 0) {
+      response.validation = { warnings }
+    }
+
+    return response
+  })
+}
+
+export {
+  badRequestResponse,
+  handleRouteError,
+  generateResponseWithValidationWarnings
+}

--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -9,11 +9,11 @@ import { getBatches } from '../common/helpers/batch.js'
 import { BULK_RESPONSE_STATUS } from '../common/constants/bulk-response-status.js'
 import {
   badRequestResponse,
+  generateResponseWithValidationWarnings,
   handleRouteError
 } from '../common/helpers/bulk-route-helpers.js'
 import { bulkReceiveMovementRequestSchema } from '../schemas/bulk-receipt.js'
 import Joi from 'joi'
-import { generateAllValidationWarnings } from '../common/helpers/validation-warnings/validation-warnings.js'
 import { metricsCounter } from '../common/helpers/metrics.js'
 
 const createBulkReceiptMovement = {
@@ -108,8 +108,10 @@ const createBulkReceiptMovement = {
       collectMetrics(createdMovements)
 
       const response = generateResponseWithValidationWarnings(
-        createdMovements.wasteInputs,
-        payload
+        payload,
+        createdMovements.wasteInputs.map(
+          ({ wasteTrackingId }) => wasteTrackingId
+        )
       )
 
       return h
@@ -140,24 +142,6 @@ function createWasteInputs(payload, wasteTrackingIds, traceId, bulkId) {
     delete wasteInput.receipt.movement.submittingOrganisation
 
     return wasteInput
-  })
-}
-
-function generateResponseWithValidationWarnings(wasteInputs, payload) {
-  return wasteInputs.map(({ wasteTrackingId }, index) => {
-    const response = { wasteTrackingId }
-    const warnings = generateAllValidationWarnings(
-      payload[index],
-      wasteTrackingId
-    )
-
-    if (warnings.length > 0) {
-      response.validation = {
-        warnings
-      }
-    }
-
-    return response
   })
 }
 

--- a/src/routes/update-bulk-receipt-movement.js
+++ b/src/routes/update-bulk-receipt-movement.js
@@ -6,6 +6,7 @@ import { updateBulkWasteInput } from '../services/movement-update-bulk.js'
 import { BULK_RESPONSE_STATUS } from '../common/constants/bulk-response-status.js'
 import {
   badRequestResponse,
+  generateResponseWithValidationWarnings,
   handleRouteError
 } from '../common/helpers/bulk-route-helpers.js'
 import { bulkUpdateMovementRequestSchema } from '../schemas/bulk-receipt.js'
@@ -200,7 +201,7 @@ const updateBulkReceiptMovement = {
       return h
         .response({
           status: BULK_RESPONSE_STATUS.MOVEMENTS_UPDATED,
-          movements
+          movements: generateResponseWithValidationWarnings(payload)
         })
         .code(HTTP_STATUS_CODES.OK)
     } catch (error) {

--- a/src/routes/update-bulk-receipt-movement.test.js
+++ b/src/routes/update-bulk-receipt-movement.test.js
@@ -175,6 +175,49 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     assertMetricsCounterWasCalled(metricsCounterSpy)
   })
 
+  it('updates multiple waste inputs and returns warnings for items containing them', async () => {
+    const updateBulkWasteInputSpy = jest.spyOn(
+      movementUpdateBulk,
+      'updateBulkWasteInput'
+    )
+    const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+
+    payload[0].wasteItems[0].disposalOrRecoveryCodes = []
+
+    const { statusCode, result } = await server.inject({
+      method: 'PUT',
+      url: `/bulk/${updateBulkId}/movements/receive`,
+      payload,
+      headers: {
+        'x-cdp-request-id': traceId
+      }
+    })
+
+    expect(statusCode).toEqual(HTTP_STATUS_CODES.OK)
+    expect(result).toEqual({
+      status: BULK_RESPONSE_STATUS.MOVEMENTS_UPDATED,
+      movements: [
+        {
+          validation: {
+            warnings: [
+              {
+                errorType: 'NotProvided',
+                key: 'wasteItems.0.disposalOrRecoveryCodes',
+                message:
+                  'wasteItems[0].disposalOrRecoveryCodes is required for proper waste tracking and compliance'
+              }
+            ]
+          }
+        },
+        {}
+      ]
+    })
+
+    expect(updateBulkWasteInputSpy).toHaveBeenCalledTimes(1)
+
+    assertMetricsCounterWasCalled(metricsCounterSpy)
+  })
+
   it('should return NO_MOVEMENTS_UPDATED when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs collection', async () => {
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
 


### PR DESCRIPTION
### Description
Ticket [DWTA-162](https://eaflood.atlassian.net/browse/DWTA-162)

Moved the `generateResponseWithValidationWarnings` function to a shared utility (`bulk-route-helpers`) for reuse across relevant bulk processes. Updated `create-bulk-receipt-movement` and `update-bulk-receipt-movement` to utilize this centralized helper, and adjusted corresponding tests to ensure proper validation of warnings while processing payloads.

[DWTA-162]: https://eaflood.atlassian.net/browse/DWTA-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ