### PR TITLE
DWTA-166 Feature: Basic receipt of waste

### DIFF
--- a/src/services/production-approval-tests/r01-single-waste-item.js
+++ b/src/services/production-approval-tests/r01-single-waste-item.js
@@ -1,0 +1,13 @@
+import { fail, pass } from './status.js'
+
+export function runScenarioR01Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  if (wasteItems.length !== 1) {
+    return fail(
+      `Expected exactly 1 waste item for R01, found ${wasteItems.length}`
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/r01-single-waste-item.js
+++ b/src/services/production-approval-tests/r01-single-waste-item.js
@@ -3,28 +3,26 @@ import { fail, pass } from './status.js'
 export function runScenarioR01Tests(wasteInput) {
   const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
 
-  if (wasteItems.length !== 1) {
-    return fail(
-      `Expected exactly 1 waste item for R01, found ${wasteItems.length}`
-    )
+  if (wasteItems.length === 0) {
+    return fail('No waste items provided')
+  }
+
+  if (wasteItems.length > 1) {
+    return fail('Multiple waste items provided')
   }
 
   const [wasteItem] = wasteItems
 
   if (!(wasteItem?.disposalOrRecoveryCodes?.length > 0)) {
-    return fail(
-      'Expected the waste item to have at least one disposal or recovery code for R01'
-    )
+    return fail('No disposal or recovery code provided')
   }
 
-  if (wasteItem.containsPops !== false) {
-    return fail('Expected the waste item to not contain POPs for R01')
+  if (wasteItem.containsPops === true) {
+    return fail('POPs components provided')
   }
 
-  if (wasteItem.containsHazardous !== false) {
-    return fail(
-      'Expected the waste item to not contain hazardous components for R01'
-    )
+  if (wasteItem.containsHazardous === true) {
+    return fail('Hazardous waste items provided')
   }
 
   return pass()

--- a/src/services/production-approval-tests/r01-single-waste-item.js
+++ b/src/services/production-approval-tests/r01-single-waste-item.js
@@ -9,5 +9,23 @@ export function runScenarioR01Tests(wasteInput) {
     )
   }
 
+  const [wasteItem] = wasteItems
+
+  if (!(wasteItem?.disposalOrRecoveryCodes?.length > 0)) {
+    return fail(
+      'Expected the waste item to have at least one disposal or recovery code for R01'
+    )
+  }
+
+  if (wasteItem.containsPops !== false) {
+    return fail('Expected the waste item to not contain POPs for R01')
+  }
+
+  if (wasteItem.containsHazardous !== false) {
+    return fail(
+      'Expected the waste item to not contain hazardous components for R01'
+    )
+  }
+
   return pass()
 }

--- a/src/services/production-approval-tests/r01-single-waste-item.test.js
+++ b/src/services/production-approval-tests/r01-single-waste-item.test.js
@@ -11,33 +11,27 @@ describe('runScenarioR01Tests', () => {
     expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
   })
 
-  it('fails when there are 0 waste items', () => {
+  it('fails with "No waste items provided" when wasteItems is empty', () => {
     const result = runScenarioR01Tests(buildWasteInput({ wasteItems: [] }))
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected exactly 1 waste item for R01, found 0'
-    )
+    expect(result.message).toBe('No waste items provided')
   })
 
-  it('fails when there are multiple waste items', () => {
+  it('fails with "No waste items provided" when wasteItems is missing', () => {
+    const result = runScenarioR01Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe('No waste items provided')
+  })
+
+  it('fails with "Multiple waste items provided" when there are multiple waste items', () => {
     const result = runScenarioR01Tests(
       buildWasteInput({ wasteItems: [buildWasteItem(), buildWasteItem()] })
     )
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected exactly 1 waste item for R01, found 2'
-    )
-  })
-
-  it('fails when wasteItems is missing', () => {
-    const result = runScenarioR01Tests({ receipt: { movement: {} } })
-
-    expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected exactly 1 waste item for R01, found 0'
-    )
+    expect(result.message).toBe('Multiple waste items provided')
   })
 
   it('fails when the waste item has no disposal or recovery codes', () => {
@@ -48,12 +42,10 @@ describe('runScenarioR01Tests', () => {
     )
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected the waste item to have at least one disposal or recovery code for R01'
-    )
+    expect(result.message).toBe('No disposal or recovery code provided')
   })
 
-  it('fails when the waste item contains POPs', () => {
+  it('fails with "POPs components provided" when the waste item contains POPs', () => {
     const result = runScenarioR01Tests(
       buildWasteInput({
         wasteItems: [buildWasteItem({ containsPops: true })]
@@ -61,12 +53,10 @@ describe('runScenarioR01Tests', () => {
     )
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected the waste item to not contain POPs for R01'
-    )
+    expect(result.message).toBe('POPs components provided')
   })
 
-  it('fails when the waste item contains hazardous components', () => {
+  it('fails with "Hazardous waste items provided" when the waste item contains hazardous components', () => {
     const result = runScenarioR01Tests(
       buildWasteInput({
         wasteItems: [buildWasteItem({ containsHazardous: true })]
@@ -74,8 +64,6 @@ describe('runScenarioR01Tests', () => {
     )
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected the waste item to not contain hazardous components for R01'
-    )
+    expect(result.message).toBe('Hazardous waste items provided')
   })
 })

--- a/src/services/production-approval-tests/r01-single-waste-item.test.js
+++ b/src/services/production-approval-tests/r01-single-waste-item.test.js
@@ -1,0 +1,42 @@
+import { runScenarioR01Tests } from './r01-single-waste-item.js'
+import { buildWasteInput, buildWasteItem } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+
+describe('runScenarioR01Tests', () => {
+  it('passes when there is exactly 1 waste item', () => {
+    const result = runScenarioR01Tests(
+      buildWasteInput({ wasteItems: [buildWasteItem()] })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when there are 0 waste items', () => {
+    const result = runScenarioR01Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected exactly 1 waste item for R01, found 0'
+    )
+  })
+
+  it('fails when there are multiple waste items', () => {
+    const result = runScenarioR01Tests(
+      buildWasteInput({ wasteItems: [buildWasteItem(), buildWasteItem()] })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected exactly 1 waste item for R01, found 2'
+    )
+  })
+
+  it('fails gracefully when wasteInput is missing waste items', () => {
+    const result = runScenarioR01Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected exactly 1 waste item for R01, found 0'
+    )
+  })
+})

--- a/src/services/production-approval-tests/r01-single-waste-item.test.js
+++ b/src/services/production-approval-tests/r01-single-waste-item.test.js
@@ -3,7 +3,7 @@ import { buildWasteInput, buildWasteItem } from './test-helpers.js'
 import { PAT_STATUS } from './status.js'
 
 describe('runScenarioR01Tests', () => {
-  it('passes when there is exactly 1 waste item', () => {
+  it('passes with 1 waste item that has a disposal or recovery code, no POPs and no hazardous', () => {
     const result = runScenarioR01Tests(
       buildWasteInput({ wasteItems: [buildWasteItem()] })
     )
@@ -31,12 +31,51 @@ describe('runScenarioR01Tests', () => {
     )
   })
 
-  it('fails gracefully when wasteInput is missing waste items', () => {
+  it('fails when wasteItems is missing', () => {
     const result = runScenarioR01Tests({ receipt: { movement: {} } })
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
     expect(result.message).toBe(
       'Expected exactly 1 waste item for R01, found 0'
+    )
+  })
+
+  it('fails when the waste item has no disposal or recovery codes', () => {
+    const result = runScenarioR01Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ disposalOrRecoveryCodes: [] })]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected the waste item to have at least one disposal or recovery code for R01'
+    )
+  })
+
+  it('fails when the waste item contains POPs', () => {
+    const result = runScenarioR01Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ containsPops: true })]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected the waste item to not contain POPs for R01'
+    )
+  })
+
+  it('fails when the waste item contains hazardous components', () => {
+    const result = runScenarioR01Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ containsHazardous: true })]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected the waste item to not contain hazardous components for R01'
     )
   })
 })

--- a/src/services/production-approval-tests/r02-multiple-waste-items.js
+++ b/src/services/production-approval-tests/r02-multiple-waste-items.js
@@ -1,0 +1,13 @@
+import { fail, pass } from './status.js'
+
+export function runScenarioR02Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  if (wasteItems.length < 2) {
+    return fail(
+      `Expected more than 1 waste item for R02, found ${wasteItems.length}`
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/r02-multiple-waste-items.test.js
+++ b/src/services/production-approval-tests/r02-multiple-waste-items.test.js
@@ -1,0 +1,43 @@
+import { runScenarioR02Tests } from './r02-multiple-waste-items.js'
+import { buildWasteInput, buildWasteItem } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+
+describe('runScenarioR02Tests', () => {
+  it('passes when there are 2 waste items', () => {
+    const result = runScenarioR02Tests(
+      buildWasteInput({ wasteItems: [buildWasteItem(), buildWasteItem()] })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when there are 3 waste items', () => {
+    const result = runScenarioR02Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem(), buildWasteItem(), buildWasteItem()]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.PASS)
+  })
+
+  it('fails when there is exactly 1 waste item', () => {
+    const result = runScenarioR02Tests(
+      buildWasteInput({ wasteItems: [buildWasteItem()] })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected more than 1 waste item for R02, found 1'
+    )
+  })
+
+  it('fails when wasteItems is missing', () => {
+    const result = runScenarioR02Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected more than 1 waste item for R02, found 0'
+    )
+  })
+})

--- a/src/services/production-approval-tests/r03-road-transport.js
+++ b/src/services/production-approval-tests/r03-road-transport.js
@@ -3,17 +3,12 @@ import { fail, pass } from './status.js'
 const ROAD = 'Road'
 
 export function runScenarioR03Tests(wasteInput) {
-  const carrier = wasteInput?.receipt?.movement?.carrier
+  const meansOfTransport =
+    wasteInput?.receipt?.movement?.carrier?.meansOfTransport
 
-  if (carrier?.meansOfTransport !== ROAD) {
+  if (meansOfTransport !== ROAD) {
     return fail(
-      `Expected carrier.meansOfTransport to be "${ROAD}" for R03, found "${carrier?.meansOfTransport ?? 'undefined'}"`
-    )
-  }
-
-  if (!carrier.vehicleRegistration) {
-    return fail(
-      'Expected carrier.vehicleRegistration to be provided for R03 road transport'
+      `Expected carrier.meansOfTransport to be "${ROAD}" for R03, found "${meansOfTransport ?? 'undefined'}"`
     )
   }
 

--- a/src/services/production-approval-tests/r03-road-transport.js
+++ b/src/services/production-approval-tests/r03-road-transport.js
@@ -1,0 +1,21 @@
+import { fail, pass } from './status.js'
+
+const ROAD = 'Road'
+
+export function runScenarioR03Tests(wasteInput) {
+  const carrier = wasteInput?.receipt?.movement?.carrier
+
+  if (carrier?.meansOfTransport !== ROAD) {
+    return fail(
+      `Expected carrier.meansOfTransport to be "${ROAD}" for R03, found "${carrier?.meansOfTransport ?? 'undefined'}"`
+    )
+  }
+
+  if (!carrier.vehicleRegistration) {
+    return fail(
+      'Expected carrier.vehicleRegistration to be provided for R03 road transport'
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/r03-road-transport.test.js
+++ b/src/services/production-approval-tests/r03-road-transport.test.js
@@ -3,10 +3,10 @@ import { buildWasteInput } from './test-helpers.js'
 import { PAT_STATUS } from './status.js'
 
 describe('runScenarioR03Tests', () => {
-  it('passes when carrier is by Road with a vehicle registration', () => {
+  it('passes when carrier meansOfTransport is Road', () => {
     const result = runScenarioR03Tests(
       buildWasteInput({
-        carrier: { meansOfTransport: 'Road', vehicleRegistration: 'AB12 CDE' }
+        carrier: { meansOfTransport: 'Road' }
       })
     )
 
@@ -16,7 +16,7 @@ describe('runScenarioR03Tests', () => {
   it('fails when meansOfTransport is not Road', () => {
     const result = runScenarioR03Tests(
       buildWasteInput({
-        carrier: { meansOfTransport: 'Rail', vehicleRegistration: 'AB12 CDE' }
+        carrier: { meansOfTransport: 'Rail' }
       })
     )
 
@@ -32,17 +32,6 @@ describe('runScenarioR03Tests', () => {
     expect(result.status).toBe(PAT_STATUS.FAIL)
     expect(result.message).toBe(
       'Expected carrier.meansOfTransport to be "Road" for R03, found "undefined"'
-    )
-  })
-
-  it('fails when Road transport has no vehicle registration', () => {
-    const result = runScenarioR03Tests(
-      buildWasteInput({ carrier: { meansOfTransport: 'Road' } })
-    )
-
-    expect(result.status).toBe(PAT_STATUS.FAIL)
-    expect(result.message).toBe(
-      'Expected carrier.vehicleRegistration to be provided for R03 road transport'
     )
   })
 })

--- a/src/services/production-approval-tests/r03-road-transport.test.js
+++ b/src/services/production-approval-tests/r03-road-transport.test.js
@@ -1,0 +1,48 @@
+import { runScenarioR03Tests } from './r03-road-transport.js'
+import { buildWasteInput } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+
+describe('runScenarioR03Tests', () => {
+  it('passes when carrier is by Road with a vehicle registration', () => {
+    const result = runScenarioR03Tests(
+      buildWasteInput({
+        carrier: { meansOfTransport: 'Road', vehicleRegistration: 'AB12 CDE' }
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when meansOfTransport is not Road', () => {
+    const result = runScenarioR03Tests(
+      buildWasteInput({
+        carrier: { meansOfTransport: 'Rail', vehicleRegistration: 'AB12 CDE' }
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected carrier.meansOfTransport to be "Road" for R03, found "Rail"'
+    )
+  })
+
+  it('fails when carrier is missing', () => {
+    const result = runScenarioR03Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected carrier.meansOfTransport to be "Road" for R03, found "undefined"'
+    )
+  })
+
+  it('fails when Road transport has no vehicle registration', () => {
+    const result = runScenarioR03Tests(
+      buildWasteInput({ carrier: { meansOfTransport: 'Road' } })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected carrier.vehicleRegistration to be provided for R03 road transport'
+    )
+  })
+})

--- a/src/services/production-approval-tests/r04-no-disposal-or-recovery-codes.js
+++ b/src/services/production-approval-tests/r04-no-disposal-or-recovery-codes.js
@@ -1,0 +1,19 @@
+import { fail, pass } from './status.js'
+
+export function runScenarioR04Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  const offendingIndexes = wasteItems
+    .map((item, index) =>
+      item?.disposalOrRecoveryCodes?.length > 0 ? index : null
+    )
+    .filter((index) => index !== null)
+
+  if (offendingIndexes.length > 0) {
+    return fail(
+      `Expected no disposal or recovery codes for R04, found codes on waste item(s) at index ${offendingIndexes.join(', ')}`
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/r04-no-disposal-or-recovery-codes.test.js
+++ b/src/services/production-approval-tests/r04-no-disposal-or-recovery-codes.test.js
@@ -1,0 +1,56 @@
+import { runScenarioR04Tests } from './r04-no-disposal-or-recovery-codes.js'
+import { buildWasteInput, buildWasteItem } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+
+describe('runScenarioR04Tests', () => {
+  it('passes when no waste items have disposal or recovery codes', () => {
+    const result = runScenarioR04Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ disposalOrRecoveryCodes: [] }),
+          buildWasteItem({ disposalOrRecoveryCodes: undefined })
+        ]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when wasteItems is empty', () => {
+    const result = runScenarioR04Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.PASS)
+  })
+
+  it('fails when a waste item has a disposal or recovery code', () => {
+    const result = runScenarioR04Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ disposalOrRecoveryCodes: [] }),
+          buildWasteItem({ disposalOrRecoveryCodes: [{ code: 'R1' }] })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 1'
+    )
+  })
+
+  it('lists every offending waste item index', () => {
+    const result = runScenarioR04Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ disposalOrRecoveryCodes: [{ code: 'R1' }] }),
+          buildWasteItem({ disposalOrRecoveryCodes: [] }),
+          buildWasteItem({ disposalOrRecoveryCodes: [{ code: 'D1' }] })
+        ]
+      })
+    )
+
+    expect(result.message).toBe(
+      'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 0, 2'
+    )
+  })
+})

--- a/src/services/production-approval-tests/r04-no-disposal-or-recovery-codes.test.js
+++ b/src/services/production-approval-tests/r04-no-disposal-or-recovery-codes.test.js
@@ -22,6 +22,12 @@ describe('runScenarioR04Tests', () => {
     expect(result.status).toBe(PAT_STATUS.PASS)
   })
 
+  it('passes when wasteItems is missing', () => {
+    const result = runScenarioR04Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.PASS)
+  })
+
   it('fails when a waste item has a disposal or recovery code', () => {
     const result = runScenarioR04Tests(
       buildWasteInput({

--- a/src/services/production-approval-tests/r05-multiple-disposal-or-recovery-codes.js
+++ b/src/services/production-approval-tests/r05-multiple-disposal-or-recovery-codes.js
@@ -1,0 +1,17 @@
+import { fail, pass } from './status.js'
+
+export function runScenarioR05Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  const hasMultipleCodes = wasteItems.some(
+    (item) => item?.disposalOrRecoveryCodes?.length > 1
+  )
+
+  if (!hasMultipleCodes) {
+    return fail(
+      'Expected at least one waste item to have multiple disposal or recovery codes for R05'
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/r05-multiple-disposal-or-recovery-codes.test.js
+++ b/src/services/production-approval-tests/r05-multiple-disposal-or-recovery-codes.test.js
@@ -1,0 +1,56 @@
+import { runScenarioR05Tests } from './r05-multiple-disposal-or-recovery-codes.js'
+import { buildWasteInput, buildWasteItem } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+
+describe('runScenarioR05Tests', () => {
+  it('passes when a waste item has multiple disposal or recovery codes', () => {
+    const result = runScenarioR05Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({
+            disposalOrRecoveryCodes: [{ code: 'R1' }, { code: 'D1' }]
+          })
+        ]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when one of several waste items has multiple codes', () => {
+    const result = runScenarioR05Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ disposalOrRecoveryCodes: [{ code: 'R1' }] }),
+          buildWasteItem({
+            disposalOrRecoveryCodes: [{ code: 'R1' }, { code: 'D5' }]
+          })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.PASS)
+  })
+
+  it('fails when no waste item has multiple disposal or recovery codes', () => {
+    const result = runScenarioR05Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ disposalOrRecoveryCodes: [{ code: 'R1' }] }),
+          buildWasteItem({ disposalOrRecoveryCodes: [{ code: 'R1' }] })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected at least one waste item to have multiple disposal or recovery codes for R05'
+    )
+  })
+
+  it('fails when wasteItems is empty', () => {
+    const result = runScenarioR05Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+  })
+})

--- a/src/services/production-approval-tests/r05-multiple-disposal-or-recovery-codes.test.js
+++ b/src/services/production-approval-tests/r05-multiple-disposal-or-recovery-codes.test.js
@@ -53,4 +53,10 @@ describe('runScenarioR05Tests', () => {
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
   })
+
+  it('fails when wasteItems is missing', () => {
+    const result = runScenarioR05Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+  })
 })

--- a/src/services/production-approval-tests/r07-dual-ewc-codes.js
+++ b/src/services/production-approval-tests/r07-dual-ewc-codes.js
@@ -1,16 +1,18 @@
 import { fail, pass } from './status.js'
 
-const DUAL_EWC_CODE_COUNT = 2
+const MIN_DUAL_EWC_CODES = 2
 
 export function runScenarioR07Tests(wasteInput) {
   const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
 
   const hasDualEwcCodes = wasteItems.some(
-    (item) => item?.ewcCodes?.length === DUAL_EWC_CODE_COUNT
+    (item) => item?.ewcCodes?.length >= MIN_DUAL_EWC_CODES
   )
 
   if (!hasDualEwcCodes) {
-    return fail('Expected at least one waste item to have 2 EWC codes for R07')
+    return fail(
+      'Expected at least one waste item to have at least 2 EWC codes for R07'
+    )
   }
 
   return pass()

--- a/src/services/production-approval-tests/r07-dual-ewc-codes.js
+++ b/src/services/production-approval-tests/r07-dual-ewc-codes.js
@@ -1,0 +1,17 @@
+import { fail, pass } from './status.js'
+
+const DUAL_EWC_CODE_COUNT = 2
+
+export function runScenarioR07Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  const hasDualEwcCodes = wasteItems.some(
+    (item) => item?.ewcCodes?.length === DUAL_EWC_CODE_COUNT
+  )
+
+  if (!hasDualEwcCodes) {
+    return fail('Expected at least one waste item to have 2 EWC codes for R07')
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/r07-dual-ewc-codes.test.js
+++ b/src/services/production-approval-tests/r07-dual-ewc-codes.test.js
@@ -1,0 +1,50 @@
+import { runScenarioR07Tests } from './r07-dual-ewc-codes.js'
+import { buildWasteInput, buildWasteItem } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+
+describe('runScenarioR07Tests', () => {
+  it('passes when a waste item has 2 EWC codes', () => {
+    const result = runScenarioR07Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ ewcCodes: ['200101', '200102'] })]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when at least one waste item has 2 EWC codes', () => {
+    const result = runScenarioR07Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ ewcCodes: ['200101'] }),
+          buildWasteItem({ ewcCodes: ['200101', '200102'] })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.PASS)
+  })
+
+  it('fails when no waste item has exactly 2 EWC codes', () => {
+    const result = runScenarioR07Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ ewcCodes: ['200101'] }),
+          buildWasteItem({ ewcCodes: ['200101', '200102', '200103'] })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected at least one waste item to have 2 EWC codes for R07'
+    )
+  })
+
+  it('fails when wasteItems is empty', () => {
+    const result = runScenarioR07Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+  })
+})

--- a/src/services/production-approval-tests/r07-dual-ewc-codes.test.js
+++ b/src/services/production-approval-tests/r07-dual-ewc-codes.test.js
@@ -13,7 +13,19 @@ describe('runScenarioR07Tests', () => {
     expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
   })
 
-  it('passes when at least one waste item has 2 EWC codes', () => {
+  it('passes when a waste item has more than 2 EWC codes', () => {
+    const result = runScenarioR07Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ ewcCodes: ['200101', '200102', '200103'] })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.PASS)
+  })
+
+  it('passes when at least one waste item has 2 or more EWC codes', () => {
     const result = runScenarioR07Tests(
       buildWasteInput({
         wasteItems: [
@@ -26,24 +38,30 @@ describe('runScenarioR07Tests', () => {
     expect(result.status).toBe(PAT_STATUS.PASS)
   })
 
-  it('fails when no waste item has exactly 2 EWC codes', () => {
+  it('fails when no waste item has 2 or more EWC codes', () => {
     const result = runScenarioR07Tests(
       buildWasteInput({
         wasteItems: [
           buildWasteItem({ ewcCodes: ['200101'] }),
-          buildWasteItem({ ewcCodes: ['200101', '200102', '200103'] })
+          buildWasteItem({ ewcCodes: ['200102'] })
         ]
       })
     )
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
     expect(result.message).toBe(
-      'Expected at least one waste item to have 2 EWC codes for R07'
+      'Expected at least one waste item to have at least 2 EWC codes for R07'
     )
   })
 
   it('fails when wasteItems is empty', () => {
     const result = runScenarioR07Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+  })
+
+  it('fails when wasteItems is missing', () => {
+    const result = runScenarioR07Tests({ receipt: { movement: {} } })
 
     expect(result.status).toBe(PAT_STATUS.FAIL)
   })

--- a/src/services/production-approval-tests/run-production-approval-tests.js
+++ b/src/services/production-approval-tests/run-production-approval-tests.js
@@ -1,0 +1,35 @@
+import { createLogger } from '../../common/helpers/logging/logger.js'
+import { SCENARIO_REGISTRY } from './scenario-registry.js'
+import { error } from './status.js'
+
+const logger = createLogger()
+
+export function runProductionApprovalTests(productionApprovalTestData) {
+  return productionApprovalTestData.map(runSingleTest)
+}
+
+function runSingleTest({ scenarioId, wasteTrackingId, wasteInput }) {
+  const runner = SCENARIO_REGISTRY[scenarioId]
+  let result
+
+  if (!runner) {
+    result = error(`Unsupported scenarioId: ${scenarioId}`)
+  } else {
+    try {
+      result = runner(wasteInput)
+    } catch (err) {
+      logger.error(
+        { err, scenarioId, wasteTrackingId },
+        'Production approval test threw an unexpected error'
+      )
+      result = error(err.message)
+    }
+  }
+
+  return {
+    scenarioId,
+    wasteTrackingId,
+    status: result.status,
+    message: result.message
+  }
+}

--- a/src/services/production-approval-tests/run-production-approval-tests.test.js
+++ b/src/services/production-approval-tests/run-production-approval-tests.test.js
@@ -64,7 +64,7 @@ describe('runProductionApprovalTests', () => {
       PAT_STATUS.FAIL,
       PAT_STATUS.PASS
     ])
-    expect(results[1].message).toContain('Expected exactly 1 waste item')
+    expect(results[1].message).toBe('Multiple waste items provided')
   })
 
   it('returns Error status for an unsupported scenarioId', () => {

--- a/src/services/production-approval-tests/run-production-approval-tests.test.js
+++ b/src/services/production-approval-tests/run-production-approval-tests.test.js
@@ -1,0 +1,113 @@
+import { runProductionApprovalTests } from './run-production-approval-tests.js'
+import { buildWasteInput, buildWasteItem } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+import * as logger from '../../common/helpers/logging/logger.js'
+
+describe('runProductionApprovalTests', () => {
+  it('returns one positional result per payload item', () => {
+    const results = runProductionApprovalTests([
+      {
+        scenarioId: 'R01',
+        wasteTrackingId: 'wt-1',
+        wasteInput: buildWasteInput({ wasteItems: [buildWasteItem()] })
+      },
+      {
+        scenarioId: 'R02',
+        wasteTrackingId: 'wt-2',
+        wasteInput: buildWasteInput({
+          wasteItems: [buildWasteItem(), buildWasteItem()]
+        })
+      }
+    ])
+
+    expect(results).toEqual([
+      {
+        scenarioId: 'R01',
+        wasteTrackingId: 'wt-1',
+        status: PAT_STATUS.PASS,
+        message: ''
+      },
+      {
+        scenarioId: 'R02',
+        wasteTrackingId: 'wt-2',
+        status: PAT_STATUS.PASS,
+        message: ''
+      }
+    ])
+  })
+
+  it('continues running tests after one fails and returns mixed results', () => {
+    const results = runProductionApprovalTests([
+      {
+        scenarioId: 'R01',
+        wasteTrackingId: 'wt-pass',
+        wasteInput: buildWasteInput({ wasteItems: [buildWasteItem()] })
+      },
+      {
+        scenarioId: 'R01',
+        wasteTrackingId: 'wt-fail',
+        wasteInput: buildWasteInput({
+          wasteItems: [buildWasteItem(), buildWasteItem()]
+        })
+      },
+      {
+        scenarioId: 'R02',
+        wasteTrackingId: 'wt-pass-2',
+        wasteInput: buildWasteInput({
+          wasteItems: [buildWasteItem(), buildWasteItem()]
+        })
+      }
+    ])
+
+    expect(results.map((r) => r.status)).toEqual([
+      PAT_STATUS.PASS,
+      PAT_STATUS.FAIL,
+      PAT_STATUS.PASS
+    ])
+    expect(results[1].message).toContain('Expected exactly 1 waste item')
+  })
+
+  it('returns Error status for an unsupported scenarioId', () => {
+    const [result] = runProductionApprovalTests([
+      {
+        scenarioId: 'R99',
+        wasteTrackingId: 'wt-1',
+        wasteInput: buildWasteInput()
+      }
+    ])
+
+    expect(result).toEqual({
+      scenarioId: 'R99',
+      wasteTrackingId: 'wt-1',
+      status: PAT_STATUS.ERROR,
+      message: 'Unsupported scenarioId: R99'
+    })
+  })
+
+  it('catches and reports thrown errors as Error status', () => {
+    const errorLoggerSpy = jest
+      .spyOn(logger.createLogger(), 'error')
+      .mockImplementation(() => {})
+
+    const wasteInput = {
+      receipt: {
+        get movement() {
+          throw new Error('boom')
+        }
+      }
+    }
+
+    const [result] = runProductionApprovalTests([
+      { scenarioId: 'R01', wasteTrackingId: 'wt-broken', wasteInput }
+    ])
+
+    expect(result).toEqual({
+      scenarioId: 'R01',
+      wasteTrackingId: 'wt-broken',
+      status: PAT_STATUS.ERROR,
+      message: 'boom'
+    })
+    expect(errorLoggerSpy).toHaveBeenCalledTimes(1)
+    errorLoggerSpy.mockRestore()
+  })
+})

--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -1,0 +1,17 @@
+import { runScenarioR01Tests } from './r01-single-waste-item.js'
+import { runScenarioR02Tests } from './r02-multiple-waste-items.js'
+import { runScenarioR03Tests } from './r03-road-transport.js'
+import { runScenarioR04Tests } from './r04-no-disposal-or-recovery-codes.js'
+import { runScenarioR05Tests } from './r05-multiple-disposal-or-recovery-codes.js'
+import { runScenarioR07Tests } from './r07-dual-ewc-codes.js'
+
+export const SCENARIO_REGISTRY = {
+  R01: runScenarioR01Tests,
+  R02: runScenarioR02Tests,
+  R03: runScenarioR03Tests,
+  R04: runScenarioR04Tests,
+  R05: runScenarioR05Tests,
+  R07: runScenarioR07Tests
+}
+
+export const SUPPORTED_SCENARIO_IDS = Object.keys(SCENARIO_REGISTRY)

--- a/src/services/production-approval-tests/status.js
+++ b/src/services/production-approval-tests/status.js
@@ -1,0 +1,11 @@
+export const PAT_STATUS = {
+  PASS: 'Pass',
+  FAIL: 'Fail',
+  ERROR: 'Error'
+}
+
+export const pass = () => ({ status: PAT_STATUS.PASS, message: '' })
+
+export const fail = (message) => ({ status: PAT_STATUS.FAIL, message })
+
+export const error = (message) => ({ status: PAT_STATUS.ERROR, message })

--- a/src/services/production-approval-tests/test-helpers.js
+++ b/src/services/production-approval-tests/test-helpers.js
@@ -1,0 +1,22 @@
+export function buildWasteInput({ wasteItems, carrier } = {}) {
+  return {
+    wasteTrackingId: 'wt-test',
+    receipt: {
+      movement: {
+        carrier: carrier ?? {
+          meansOfTransport: 'Road',
+          vehicleRegistration: 'AB12 CDE'
+        },
+        wasteItems: wasteItems ?? [buildWasteItem()]
+      }
+    }
+  }
+}
+
+export function buildWasteItem(overrides = {}) {
+  return {
+    ewcCodes: ['200101'],
+    disposalOrRecoveryCodes: [{ code: 'R1' }],
+    ...overrides
+  }
+}

--- a/src/services/production-approval-tests/test-helpers.js
+++ b/src/services/production-approval-tests/test-helpers.js
@@ -17,6 +17,8 @@ export function buildWasteItem(overrides = {}) {
   return {
     ewcCodes: ['200101'],
     disposalOrRecoveryCodes: [{ code: 'R1' }],
+    containsPops: false,
+    containsHazardous: false,
     ...overrides
   }
 }


### PR DESCRIPTION
### Description
Ticket [DWTA-166](https://eaflood.atlassian.net/browse/DWTA-166)

This pull request introduces the implementation of production approval test scenarios (R01–R07) and centralizes the test execution process. Key updates include:

- Added test scenarios for:
  - Single waste item validation (R01)
  - Multiple waste items validation (R02)
  - Road transport validation (R03)
  - No disposal/recovery codes validation (R04)
  - Multiple disposal/recovery codes validation (R05)
  - Dual EWC codes validation (R07)
- Created a `runProductionApprovalTests` utility for centralized test routing and result aggregation.
- Established a `SCENARIO_REGISTRY` to map tests to scenario IDs.
- Wrote comprehensive unit tests for individual scenarios and overall routing logic (`runProductionApprovalTests.test.js`).

[DWTA-166]: https://eaflood.atlassian.net/browse/DWTA-166?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ