### PR TITLE
DWTA-167 Add Carrier Details PAT

### DIFF
--- a/src/services/production-approval-tests/c02-reason-for-no-carrier-registration-number.js
+++ b/src/services/production-approval-tests/c02-reason-for-no-carrier-registration-number.js
@@ -1,0 +1,14 @@
+import { fail, pass } from './status.js'
+
+export function runScenarioC02Tests(wasteInput) {
+  const reasonForNoRegistrationNumber =
+    wasteInput?.receipt?.movement?.carrier?.reasonForNoRegistrationNumber
+
+  if (!reasonForNoRegistrationNumber) {
+    return fail(
+      'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/c02-reason-for-no-carrier-registration-number.test.js
+++ b/src/services/production-approval-tests/c02-reason-for-no-carrier-registration-number.test.js
@@ -1,0 +1,40 @@
+import { runScenarioC02Tests } from './c02-reason-for-no-carrier-registration-number.js'
+import { buildWasteInput } from './test-helpers.js'
+import { PAT_STATUS } from './status.js'
+import { REASONS_FOR_NO_REGISTRATION_NUMBER } from '../../common/constants/reasons-for-no-registration-number.js'
+
+describe('runScenarioC02Tests', () => {
+  it('passes when carrier reasonForNoRegistrationNumber is given', () => {
+    const result = runScenarioC02Tests(
+      buildWasteInput({
+        carrier: {
+          reasonForNoRegistrationNumber: REASONS_FOR_NO_REGISTRATION_NUMBER[0]
+        }
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when reasonForNoRegistrationNumber is not given', () => {
+    const result = runScenarioC02Tests(
+      buildWasteInput({
+        carrier: {}
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
+    )
+  })
+
+  it('fails when carrier is missing', () => {
+    const result = runScenarioC02Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected carrier.reasonForNoRegistrationNumber to be given for C02'
+    )
+  })
+})

--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -4,6 +4,7 @@ import { runScenarioR03Tests } from './r03-road-transport.js'
 import { runScenarioR04Tests } from './r04-no-disposal-or-recovery-codes.js'
 import { runScenarioR05Tests } from './r05-multiple-disposal-or-recovery-codes.js'
 import { runScenarioR07Tests } from './r07-dual-ewc-codes.js'
+import { runScenarioC02Tests } from './c02-reason-for-no-carrier-registration-number.js'
 
 export const SCENARIO_REGISTRY = {
   R01: runScenarioR01Tests,
@@ -11,7 +12,8 @@ export const SCENARIO_REGISTRY = {
   R03: runScenarioR03Tests,
   R04: runScenarioR04Tests,
   R05: runScenarioR05Tests,
-  R07: runScenarioR07Tests
+  R07: runScenarioR07Tests,
+  C02: runScenarioC02Tests
 }
 
 export const SUPPORTED_SCENARIO_IDS = Object.keys(SCENARIO_REGISTRY)


### PR DESCRIPTION
Ticket [DWTA-167](https://eaflood.atlassian.net/browse/DWTA-167)

This PR follows the PAT scenario tests pattern to add a test for scenario C02, which checks that the waste input contains the `carrier.reasonForNoRegistrationNumber` field.

[DWTA-167]: https://eaflood.atlassian.net/browse/DWTA-167?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ