### PR TITLE
DWT-177 Update publish workflow node version for test coverage to v22

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -27,8 +27,13 @@ jobs:
         uses: DEFRA/cdp-build-action/build@main
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Create Test Coverage Reports
-        run: |
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+      - run: |
           npm ci
           npm run format:check
           npm run lint


### PR DESCRIPTION
Ticket [DWTA_177](https://eaflood.atlassian.net/browse/DWTA-177)

Update publish workflow node version for test coverage to v22

Previously the node version for this job wasn't specified so it defaulted to node v20, however in the Production Approval Tests endpoint we're using `Set.difference()` , which requires node v22

This is similar to how it's done in `.github/workflows/check-pull-request.yml`