### PR TITLE
Move PAT scenarios into /scenarios directory

### DIFF
--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -1,10 +1,10 @@
-import { runScenarioR01Tests } from './r01-single-waste-item.js'
-import { runScenarioR02Tests } from './r02-multiple-waste-items.js'
-import { runScenarioR03Tests } from './r03-road-transport.js'
-import { runScenarioR04Tests } from './r04-no-disposal-or-recovery-codes.js'
-import { runScenarioR05Tests } from './r05-multiple-disposal-or-recovery-codes.js'
-import { runScenarioR07Tests } from './r07-dual-ewc-codes.js'
-import { runScenarioC02Tests } from './c02-reason-for-no-carrier-registration-number.js'
+import { runScenarioR01Tests } from './scenarios/r01-single-waste-item.js'
+import { runScenarioR02Tests } from './scenarios/r02-multiple-waste-items.js'
+import { runScenarioR03Tests } from './scenarios/r03-road-transport.js'
+import { runScenarioR04Tests } from './scenarios/r04-no-disposal-or-recovery-codes.js'
+import { runScenarioR05Tests } from './scenarios/r05-multiple-disposal-or-recovery-codes.js'
+import { runScenarioR07Tests } from './scenarios/r07-dual-ewc-codes.js'
+import { runScenarioC02Tests } from './scenarios/c02-reason-for-no-carrier-registration-number.js'
 
 export const SCENARIO_REGISTRY = {
   R01: runScenarioR01Tests,

--- a/src/services/production-approval-tests/scenarios/c02-reason-for-no-carrier-registration-number.js
+++ b/src/services/production-approval-tests/scenarios/c02-reason-for-no-carrier-registration-number.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 export function runScenarioC02Tests(wasteInput) {
   const reasonForNoRegistrationNumber =

--- a/src/services/production-approval-tests/scenarios/c02-reason-for-no-carrier-registration-number.test.js
+++ b/src/services/production-approval-tests/scenarios/c02-reason-for-no-carrier-registration-number.test.js
@@ -1,7 +1,7 @@
 import { runScenarioC02Tests } from './c02-reason-for-no-carrier-registration-number.js'
-import { buildWasteInput } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
-import { REASONS_FOR_NO_REGISTRATION_NUMBER } from '../../common/constants/reasons-for-no-registration-number.js'
+import { buildWasteInput } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
+import { REASONS_FOR_NO_REGISTRATION_NUMBER } from '../../../common/constants/reasons-for-no-registration-number.js'
 
 describe('runScenarioC02Tests', () => {
   it('passes when carrier reasonForNoRegistrationNumber is given', () => {

--- a/src/services/production-approval-tests/scenarios/r01-single-waste-item.js
+++ b/src/services/production-approval-tests/scenarios/r01-single-waste-item.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 export function runScenarioR01Tests(wasteInput) {
   const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []

--- a/src/services/production-approval-tests/scenarios/r01-single-waste-item.test.js
+++ b/src/services/production-approval-tests/scenarios/r01-single-waste-item.test.js
@@ -1,6 +1,6 @@
 import { runScenarioR01Tests } from './r01-single-waste-item.js'
-import { buildWasteInput, buildWasteItem } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
 
 describe('runScenarioR01Tests', () => {
   it('passes with 1 waste item that has a disposal or recovery code, no POPs and no hazardous', () => {

--- a/src/services/production-approval-tests/scenarios/r02-multiple-waste-items.js
+++ b/src/services/production-approval-tests/scenarios/r02-multiple-waste-items.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 export function runScenarioR02Tests(wasteInput) {
   const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []

--- a/src/services/production-approval-tests/scenarios/r02-multiple-waste-items.test.js
+++ b/src/services/production-approval-tests/scenarios/r02-multiple-waste-items.test.js
@@ -1,6 +1,6 @@
 import { runScenarioR02Tests } from './r02-multiple-waste-items.js'
-import { buildWasteInput, buildWasteItem } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
 
 describe('runScenarioR02Tests', () => {
   it('passes when there are 2 waste items', () => {

--- a/src/services/production-approval-tests/scenarios/r03-road-transport.js
+++ b/src/services/production-approval-tests/scenarios/r03-road-transport.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 const ROAD = 'Road'
 

--- a/src/services/production-approval-tests/scenarios/r03-road-transport.test.js
+++ b/src/services/production-approval-tests/scenarios/r03-road-transport.test.js
@@ -1,6 +1,6 @@
 import { runScenarioR03Tests } from './r03-road-transport.js'
-import { buildWasteInput } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
+import { buildWasteInput } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
 
 describe('runScenarioR03Tests', () => {
   it('passes when carrier meansOfTransport is Road', () => {

--- a/src/services/production-approval-tests/scenarios/r04-no-disposal-or-recovery-codes.js
+++ b/src/services/production-approval-tests/scenarios/r04-no-disposal-or-recovery-codes.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 export function runScenarioR04Tests(wasteInput) {
   const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []

--- a/src/services/production-approval-tests/scenarios/r04-no-disposal-or-recovery-codes.test.js
+++ b/src/services/production-approval-tests/scenarios/r04-no-disposal-or-recovery-codes.test.js
@@ -1,6 +1,6 @@
 import { runScenarioR04Tests } from './r04-no-disposal-or-recovery-codes.js'
-import { buildWasteInput, buildWasteItem } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
 
 describe('runScenarioR04Tests', () => {
   it('passes when no waste items have disposal or recovery codes', () => {

--- a/src/services/production-approval-tests/scenarios/r05-multiple-disposal-or-recovery-codes.js
+++ b/src/services/production-approval-tests/scenarios/r05-multiple-disposal-or-recovery-codes.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 export function runScenarioR05Tests(wasteInput) {
   const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []

--- a/src/services/production-approval-tests/scenarios/r05-multiple-disposal-or-recovery-codes.test.js
+++ b/src/services/production-approval-tests/scenarios/r05-multiple-disposal-or-recovery-codes.test.js
@@ -1,6 +1,6 @@
 import { runScenarioR05Tests } from './r05-multiple-disposal-or-recovery-codes.js'
-import { buildWasteInput, buildWasteItem } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
 
 describe('runScenarioR05Tests', () => {
   it('passes when a waste item has multiple disposal or recovery codes', () => {

--- a/src/services/production-approval-tests/scenarios/r07-dual-ewc-codes.js
+++ b/src/services/production-approval-tests/scenarios/r07-dual-ewc-codes.js
@@ -1,4 +1,4 @@
-import { fail, pass } from './status.js'
+import { fail, pass } from '../status.js'
 
 const MIN_DUAL_EWC_CODES = 2
 

--- a/src/services/production-approval-tests/scenarios/r07-dual-ewc-codes.test.js
+++ b/src/services/production-approval-tests/scenarios/r07-dual-ewc-codes.test.js
@@ -1,6 +1,6 @@
 import { runScenarioR07Tests } from './r07-dual-ewc-codes.js'
-import { buildWasteInput, buildWasteItem } from './test-helpers.js'
-import { PAT_STATUS } from './status.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
 
 describe('runScenarioR07Tests', () => {
   it('passes when a waste item has 2 EWC codes', () => {


### PR DESCRIPTION
This change moves the PAT scenarios into a `/scenarios` directory, which may help organisation as more scenarios and unit tests are added.

This change is only moving existing files and contains no code changes except for updating import paths