### PR TITLE
DWTA-168 Broker or Dealer involvement

### DIFF
--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -6,6 +6,7 @@ import { runScenarioR05Tests } from './scenarios/r05-multiple-disposal-or-recove
 import { runScenarioR07Tests } from './scenarios/r07-dual-ewc-codes.js'
 import { runScenarioC02Tests } from './scenarios/c02-reason-for-no-carrier-registration-number.js'
 import { runScenarioP01Tests } from './scenarios/p01-pops-components.js'
+import { runScenarioB01Tests } from './scenarios/b01-broker-dealer-involvement.js'
 
 export const SCENARIO_REGISTRY = {
   R01: runScenarioR01Tests,
@@ -15,7 +16,8 @@ export const SCENARIO_REGISTRY = {
   R05: runScenarioR05Tests,
   R07: runScenarioR07Tests,
   C02: runScenarioC02Tests,
-  P01: runScenarioP01Tests
+  P01: runScenarioP01Tests,
+  B01: runScenarioB01Tests
 }
 
 export const SUPPORTED_SCENARIO_IDS = Object.keys(SCENARIO_REGISTRY)

--- a/src/services/production-approval-tests/scenarios/b01-broker-dealer-involvement.js
+++ b/src/services/production-approval-tests/scenarios/b01-broker-dealer-involvement.js
@@ -1,0 +1,11 @@
+import { fail, pass } from '../status.js'
+
+export function runScenarioB01Tests(wasteInput) {
+  const brokerOrDealer = wasteInput?.receipt?.movement?.brokerOrDealer
+
+  if (!brokerOrDealer?.organisationName) {
+    return fail('No broker or dealer involvement in the movement')
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/scenarios/b01-broker-dealer-involvement.test.js
+++ b/src/services/production-approval-tests/scenarios/b01-broker-dealer-involvement.test.js
@@ -1,0 +1,42 @@
+import { runScenarioB01Tests } from './b01-broker-dealer-involvement.js'
+import { buildWasteInput } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
+
+describe('runScenarioB01Tests', () => {
+  it('passes when brokerOrDealer is provided with an organisationName', () => {
+    const result = runScenarioB01Tests(
+      buildWasteInput({
+        brokerOrDealer: { organisationName: 'Test Broker' }
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when brokerOrDealer is missing', () => {
+    const result = runScenarioB01Tests(buildWasteInput())
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'No broker or dealer involvement in the movement'
+    )
+  })
+
+  it('fails when brokerOrDealer is provided without an organisationName', () => {
+    const result = runScenarioB01Tests(buildWasteInput({ brokerOrDealer: {} }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'No broker or dealer involvement in the movement'
+    )
+  })
+
+  it('fails when movement is missing', () => {
+    const result = runScenarioB01Tests({ receipt: {} })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'No broker or dealer involvement in the movement'
+    )
+  })
+})

--- a/src/services/production-approval-tests/test-helpers.js
+++ b/src/services/production-approval-tests/test-helpers.js
@@ -1,15 +1,19 @@
-export function buildWasteInput({ wasteItems, carrier } = {}) {
+export function buildWasteInput({ wasteItems, carrier, brokerOrDealer } = {}) {
+  const movement = {
+    carrier: carrier ?? {
+      meansOfTransport: 'Road',
+      vehicleRegistration: 'AB12 CDE'
+    },
+    wasteItems: wasteItems ?? [buildWasteItem()]
+  }
+
+  if (brokerOrDealer !== undefined) {
+    movement.brokerOrDealer = brokerOrDealer
+  }
+
   return {
     wasteTrackingId: 'wt-test',
-    receipt: {
-      movement: {
-        carrier: carrier ?? {
-          meansOfTransport: 'Road',
-          vehicleRegistration: 'AB12 CDE'
-        },
-        wasteItems: wasteItems ?? [buildWasteItem()]
-      }
-    }
+    receipt: { movement }
   }
 }
 


### PR DESCRIPTION
### Description
Ticket [DWTA-168](https://eaflood.atlassian.net/browse/DWTA-168)

This pull request introduces functionality and tests for scenario B01, focusing on broker/dealer involvement in waste movements.ll request introduces functionality and tests for scenario B01, focusing on broker/dealer involvement in waste movements.

- Added `runScenarioB01Tests` to test broker/dealer participation mechanics in waste movements.
- Extended `buildWasteInput` to handle `brokerOrDealer` attribute customization.
- Registered scenario B01 in the `SCENARIO_REGISTRY` for streamlined test integration.

[DWTA-168]: https://eaflood.atlassian.net/browse/DWTA-168?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ