### PR TITLE
DWT-177 - Add POPs components PAT scenario

### DIFF
--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -5,6 +5,7 @@ import { runScenarioR04Tests } from './scenarios/r04-no-disposal-or-recovery-cod
 import { runScenarioR05Tests } from './scenarios/r05-multiple-disposal-or-recovery-codes.js'
 import { runScenarioR07Tests } from './scenarios/r07-dual-ewc-codes.js'
 import { runScenarioC02Tests } from './scenarios/c02-reason-for-no-carrier-registration-number.js'
+import { runScenarioP01Tests } from './scenarios/p01-pops-components.js'
 
 export const SCENARIO_REGISTRY = {
   R01: runScenarioR01Tests,
@@ -13,7 +14,8 @@ export const SCENARIO_REGISTRY = {
   R04: runScenarioR04Tests,
   R05: runScenarioR05Tests,
   R07: runScenarioR07Tests,
-  C02: runScenarioC02Tests
+  C02: runScenarioC02Tests,
+  P01: runScenarioP01Tests
 }
 
 export const SUPPORTED_SCENARIO_IDS = Object.keys(SCENARIO_REGISTRY)

--- a/src/services/production-approval-tests/scenarios/p01-pops-components.js
+++ b/src/services/production-approval-tests/scenarios/p01-pops-components.js
@@ -1,0 +1,17 @@
+import { fail, pass } from '../status.js'
+
+export function runScenarioP01Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  const haveSomeWasteItemsGotMultiplePopsComponents = wasteItems.some(
+    (item) => item?.pops?.components?.length > 1
+  )
+
+  if (!haveSomeWasteItemsGotMultiplePopsComponents) {
+    return fail(
+      'Expected one or more waste items to have multiple POPs components'
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/scenarios/p01-pops-components.test.js
+++ b/src/services/production-approval-tests/scenarios/p01-pops-components.test.js
@@ -1,0 +1,64 @@
+import { runScenarioP01Tests } from './p01-pops-components.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
+
+describe('runScenarioP01Tests', () => {
+  it('passes when all waste items have multiple POPs components', () => {
+    const result = runScenarioP01Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ pops: { components: [{}, {}] } })]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when some waste items have multiple POPs components', () => {
+    const result = runScenarioP01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem(),
+          buildWasteItem({ pops: {} }),
+          buildWasteItem({ pops: { components: [{}] } }),
+          buildWasteItem({ pops: { components: [{}, {}] } })
+        ]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when no waste items have multiple POPs components', () => {
+    const result = runScenarioP01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ pops: { components: [{}] } }),
+          buildWasteItem({ pops: { components: [{}] } })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have multiple POPs components'
+    )
+  })
+
+  it('fails when wasteItems is empty', () => {
+    const result = runScenarioP01Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have multiple POPs components'
+    )
+  })
+
+  it('fails when wasteItems is missing', () => {
+    const result = runScenarioP01Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have multiple POPs components'
+    )
+  })
+})


### PR DESCRIPTION
Ticket [DWTA-177](https://eaflood.atlassian.net/browse/DWTA-178)

Changes:
- Added a PAT scenario for checking that at least one of the waste items in the waste input has multiple POPs components
- Added comprehensive unit tests

[DWTA-177]: https://eaflood.atlassian.net/browse/DWTA-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ