### PR TITLE
DWTA-179 Hazardous waste

### DIFF
--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -7,6 +7,8 @@ import { runScenarioR07Tests } from './scenarios/r07-dual-ewc-codes.js'
 import { runScenarioC02Tests } from './scenarios/c02-reason-for-no-carrier-registration-number.js'
 import { runScenarioP01Tests } from './scenarios/p01-pops-components.js'
 import { runScenarioB01Tests } from './scenarios/b01-broker-dealer-involvement.js'
+import { runScenarioH01Tests } from './scenarios/h01-multiple-hazardous-components.js'
+import { runScenarioH03Tests } from './scenarios/h03-reason-for-no-consignment-code.js'
 
 export const SCENARIO_REGISTRY = {
   R01: runScenarioR01Tests,
@@ -17,7 +19,9 @@ export const SCENARIO_REGISTRY = {
   R07: runScenarioR07Tests,
   C02: runScenarioC02Tests,
   P01: runScenarioP01Tests,
-  B01: runScenarioB01Tests
+  B01: runScenarioB01Tests,
+  H01: runScenarioH01Tests,
+  H03: runScenarioH03Tests
 }
 
 export const SUPPORTED_SCENARIO_IDS = Object.keys(SCENARIO_REGISTRY)

--- a/src/services/production-approval-tests/scenarios/h01-multiple-hazardous-components.js
+++ b/src/services/production-approval-tests/scenarios/h01-multiple-hazardous-components.js
@@ -1,0 +1,17 @@
+import { fail, pass } from '../status.js'
+
+export function runScenarioH01Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  const haveSomeWasteItemsGotMultipleHazardousComponents = wasteItems.some(
+    (item) => item?.hazardous?.components?.length > 1
+  )
+
+  if (!haveSomeWasteItemsGotMultipleHazardousComponents) {
+    return fail(
+      'Expected one or more waste items to have multiple hazardous components'
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/scenarios/h01-multiple-hazardous-components.test.js
+++ b/src/services/production-approval-tests/scenarios/h01-multiple-hazardous-components.test.js
@@ -1,0 +1,64 @@
+import { runScenarioH01Tests } from './h01-multiple-hazardous-components.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
+
+describe('runScenarioH01Tests', () => {
+  it('passes when all waste items have multiple hazardous components', () => {
+    const result = runScenarioH01Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ hazardous: { components: [{}, {}] } })]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when some waste items have multiple hazardous components', () => {
+    const result = runScenarioH01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem(),
+          buildWasteItem({ hazardous: {} }),
+          buildWasteItem({ hazardous: { components: [{}] } }),
+          buildWasteItem({ hazardous: { components: [{}, {}] } })
+        ]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when no waste items have multiple hazardous components', () => {
+    const result = runScenarioH01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({ hazardous: { components: [{}] } }),
+          buildWasteItem({ hazardous: { components: [{}] } })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have multiple hazardous components'
+    )
+  })
+
+  it('fails when wasteItems is empty', () => {
+    const result = runScenarioH01Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have multiple hazardous components'
+    )
+  })
+
+  it('fails when wasteItems is missing', () => {
+    const result = runScenarioH01Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have multiple hazardous components'
+    )
+  })
+})

--- a/src/services/production-approval-tests/scenarios/h03-reason-for-no-consignment-code.js
+++ b/src/services/production-approval-tests/scenarios/h03-reason-for-no-consignment-code.js
@@ -1,0 +1,12 @@
+import { fail, pass } from '../status.js'
+
+export function runScenarioH03Tests(wasteInput) {
+  const reasonForNoConsignmentCode =
+    wasteInput?.receipt?.movement?.reasonForNoConsignmentCode
+
+  if (!reasonForNoConsignmentCode) {
+    return fail('Expected reasonForNoConsignmentCode to be given for H03')
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/scenarios/h03-reason-for-no-consignment-code.test.js
+++ b/src/services/production-approval-tests/scenarios/h03-reason-for-no-consignment-code.test.js
@@ -1,0 +1,44 @@
+import { runScenarioH03Tests } from './h03-reason-for-no-consignment-code.js'
+import { buildWasteInput } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
+
+describe('runScenarioH03Tests', () => {
+  it('passes when reasonForNoConsignmentCode is provided', () => {
+    const result = runScenarioH03Tests(
+      buildWasteInput({
+        reasonForNoConsignmentCode: 'Carrier did not provide consignment code'
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when reasonForNoConsignmentCode is missing', () => {
+    const result = runScenarioH03Tests(buildWasteInput())
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected reasonForNoConsignmentCode to be given for H03'
+    )
+  })
+
+  it('fails when reasonForNoConsignmentCode is an empty string', () => {
+    const result = runScenarioH03Tests(
+      buildWasteInput({ reasonForNoConsignmentCode: '' })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected reasonForNoConsignmentCode to be given for H03'
+    )
+  })
+
+  it('fails when movement is missing', () => {
+    const result = runScenarioH03Tests({ receipt: {} })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected reasonForNoConsignmentCode to be given for H03'
+    )
+  })
+})

--- a/src/services/production-approval-tests/test-helpers.js
+++ b/src/services/production-approval-tests/test-helpers.js
@@ -1,4 +1,9 @@
-export function buildWasteInput({ wasteItems, carrier, brokerOrDealer } = {}) {
+export function buildWasteInput({
+  wasteItems,
+  carrier,
+  brokerOrDealer,
+  reasonForNoConsignmentCode
+} = {}) {
   const movement = {
     carrier: carrier ?? {
       meansOfTransport: 'Road',
@@ -9,6 +14,10 @@ export function buildWasteInput({ wasteItems, carrier, brokerOrDealer } = {}) {
 
   if (brokerOrDealer !== undefined) {
     movement.brokerOrDealer = brokerOrDealer
+  }
+
+  if (reasonForNoConsignmentCode !== undefined) {
+    movement.reasonForNoConsignmentCode = reasonForNoConsignmentCode
   }
 
   return {


### PR DESCRIPTION
### Description
Ticket [DWTA-179](https://eaflood.atlassian.net/browse/DWTA-179)

- Implemented functionality for scenario H01 to validate waste items with multiple hazardous components.
- Implemented functionality for scenario H03 to validate the presence of a reason for no consignment code.
- Added unit tests to ensure correct behavior for both scenarios across various conditions.
- Extended `buildWasteInput` helper to support the `reasonForNoConsignmentCode`.
- Registered scenarios H01 and H03 in `SCENARIO_REGISTRY` for improved test routing. 

[DWTA-179]: https://eaflood.atlassian.net/browse/DWTA-179?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ