### PR TITLE
DWT-180 Add POPs and Hazardous components PAT scenario

### DIFF
--- a/src/services/production-approval-tests/scenario-registry.js
+++ b/src/services/production-approval-tests/scenario-registry.js
@@ -9,6 +9,7 @@ import { runScenarioP01Tests } from './scenarios/p01-pops-components.js'
 import { runScenarioB01Tests } from './scenarios/b01-broker-dealer-involvement.js'
 import { runScenarioH01Tests } from './scenarios/h01-multiple-hazardous-components.js'
 import { runScenarioH03Tests } from './scenarios/h03-reason-for-no-consignment-code.js'
+import { runScenarioX01Tests } from './scenarios/x01-pops-and-hazardous-components.js'
 
 export const SCENARIO_REGISTRY = {
   R01: runScenarioR01Tests,
@@ -21,7 +22,8 @@ export const SCENARIO_REGISTRY = {
   P01: runScenarioP01Tests,
   B01: runScenarioB01Tests,
   H01: runScenarioH01Tests,
-  H03: runScenarioH03Tests
+  H03: runScenarioH03Tests,
+  X01: runScenarioX01Tests
 }
 
 export const SUPPORTED_SCENARIO_IDS = Object.keys(SCENARIO_REGISTRY)

--- a/src/services/production-approval-tests/scenarios/x01-pops-and-hazardous-components.js
+++ b/src/services/production-approval-tests/scenarios/x01-pops-and-hazardous-components.js
@@ -1,0 +1,19 @@
+import { fail, pass } from '../status.js'
+
+export function runScenarioX01Tests(wasteInput) {
+  const wasteItems = wasteInput?.receipt?.movement?.wasteItems ?? []
+
+  const haveSomeWasteItemsGotPopsAndHazardousComponents = wasteItems.some(
+    (item) =>
+      item?.pops?.components?.length > 0 &&
+      item?.hazardous?.components?.length > 0
+  )
+
+  if (!haveSomeWasteItemsGotPopsAndHazardousComponents) {
+    return fail(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  }
+
+  return pass()
+}

--- a/src/services/production-approval-tests/scenarios/x01-pops-and-hazardous-components.test.js
+++ b/src/services/production-approval-tests/scenarios/x01-pops-and-hazardous-components.test.js
@@ -1,0 +1,123 @@
+import { runScenarioX01Tests } from './x01-pops-and-hazardous-components.js'
+import { buildWasteInput, buildWasteItem } from '../test-helpers.js'
+import { PAT_STATUS } from '../status.js'
+
+describe('runScenarioX01Tests', () => {
+  it('passes when all waste items have POPs and Hazardous components', () => {
+    const result = runScenarioX01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({
+            pops: { components: [{}] },
+            hazardous: { components: [{}] }
+          })
+        ]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('passes when some waste items have POPs and Hazardous components', () => {
+    const result = runScenarioX01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem(),
+          buildWasteItem({ pops: {} }),
+          buildWasteItem({ hazardous: {} }),
+          buildWasteItem({
+            pops: { components: [{}] },
+            hazardous: { components: [{}] }
+          })
+        ]
+      })
+    )
+
+    expect(result).toEqual({ status: PAT_STATUS.PASS, message: '' })
+  })
+
+  it('fails when no waste items have POPs components', () => {
+    const result = runScenarioX01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({
+            pops: {},
+            hazardous: { components: [{}] }
+          })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  })
+
+  it('fails when no waste items have Hazardous components', () => {
+    const result = runScenarioX01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({
+            pops: { components: [{}] },
+            hazardous: {}
+          })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  })
+
+  it('fails when no waste items have POPs or Hazardous components (missing components property)', () => {
+    const result = runScenarioX01Tests(
+      buildWasteInput({
+        wasteItems: [buildWasteItem({ pops: {}, hazardous: {} })]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  })
+
+  it('fails when no waste items have POPs or Hazardous components (empty components array)', () => {
+    const result = runScenarioX01Tests(
+      buildWasteInput({
+        wasteItems: [
+          buildWasteItem({
+            pops: { components: [] },
+            hazardous: { components: [] }
+          })
+        ]
+      })
+    )
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  })
+
+  it('fails when wasteItems is empty', () => {
+    const result = runScenarioX01Tests(buildWasteInput({ wasteItems: [] }))
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  })
+
+  it('fails when wasteItems is missing', () => {
+    const result = runScenarioX01Tests({ receipt: { movement: {} } })
+
+    expect(result.status).toBe(PAT_STATUS.FAIL)
+    expect(result.message).toBe(
+      'Expected one or more waste items to have POPs and Hazardous components'
+    )
+  })
+})


### PR DESCRIPTION
Ticket [DWTA-180](https://eaflood.atlassian.net/browse/DWTA-180)

Changes:
- Add PAT scenario (`runScenarioX01Tests`) to check that some of the waste items in the given waste input have POPs and Hazardous components
- Add comprehensive unit tests to ensure the correct functioning of `runScenarioX01Tests`
- Add `runScenarioX01Tests` to the scenario registry so it can be used by the API endpoint 

[DWTA-180]: https://eaflood.atlassian.net/browse/DWTA-180?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ