### PR TITLE
npm audit-fix hapi-swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,7 @@
         "@hapi/basic": "7.0.2",
         "@hapi/boom": "10.0.1",
         "@hapi/hapi": "21.3.12",
-        "@hapi/inert": "7.1.0",
+        "@hapi/inert": "7.1.1",
         "@hapi/vision": "7.0.3",
         "aws-embedded-metrics": "4.2.0",
         "aws4": "1.13.2",
@@ -28,7 +28,7 @@
         "hapi-pulse": "3.0.1",
         "hapi-swagger": "17.3.2",
         "https-proxy-agent": "7.0.5",
-        "joi": "17.13.3",
+        "joi": "18.2.1",
         "mongo-locks": "3.0.2",
         "mongodb": "6.10.0",
         "mongodb-memory-server": "10.3.0",
@@ -1959,24 +1959,6 @@
         "node": ">=22"
       }
     },
-    "node_modules/@defra/cdp-auditing/node_modules/joi": {
-      "version": "18.0.1",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.1.tgz",
-      "integrity": "sha512-IiQpRyypSnLisQf3PwuN2eIHAsAIGZIrLZkd4zdvIar2bDyhM91ubRjy8a3eYablXsh9BeI/c7dmPYHca5qtoA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
     "node_modules/@defra/cdp-auditing/node_modules/pino": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/pino/-/pino-10.1.0.tgz",
@@ -2435,9 +2417,9 @@
       "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/inert": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.0.tgz",
-      "integrity": "sha512-5X+cl/Ozm0U9uPGGX1dSKhnhTQIf161bH/kkTN9OBVAZKFG+nrj8j/NMj6S1zBBZWmQrkVRNPfCUGrXzB4fCFQ==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/inert/-/inert-7.1.1.tgz",
+      "integrity": "sha512-vKSTXYbk1cDt7sLdmRIj8CofJRCcjAH9fUCUJViVzqb7Vi+ajUSfz+pAdwwY315BddwGdoXk0H3i94S0JWEKGQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
         "@hapi/ammo": "^6.0.1",
@@ -3971,33 +3953,6 @@
         "node": ">=10"
       }
     },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/address/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -4026,9 +3981,9 @@
       }
     },
     "node_modules/@standard-schema/spec": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
-      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "license": "MIT"
     },
     "node_modules/@stylistic/eslint-plugin": {
@@ -7522,34 +7477,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/hapi-pulse/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/hapi-pulse/node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/hapi-pulse/node_modules/joi": {
-      "version": "17.9.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.9.2.tgz",
-      "integrity": "sha512-Itk/r+V4Dx0V3c7RLFdRh12IOjySm2/WGPMubBT92cQvRfYZhPM2W0hZlctjj72iES8jsRCwp7S/cRmWBnJ4nw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/topo": "^5.0.0",
-        "@sideway/address": "^4.1.3",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
     "node_modules/hapi-swagger": {
       "version": "17.3.2",
       "resolved": "https://registry.npmjs.org/hapi-swagger/-/hapi-swagger-17.3.2.tgz",
@@ -9031,31 +8958,21 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "18.2.1",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
+      "integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
-      }
-    },
-    "node_modules/joi/node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/joi/node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/joycon": {
@@ -11330,9 +11247,9 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@hapi/basic": "7.0.2",
     "@hapi/boom": "10.0.1",
     "@hapi/hapi": "21.3.12",
-    "@hapi/inert": "7.1.0",
+    "@hapi/inert": "7.1.1",
     "@hapi/vision": "7.0.3",
     "aws-embedded-metrics": "4.2.0",
     "aws4": "1.13.2",
@@ -46,7 +46,7 @@
     "hapi-pulse": "3.0.1",
     "hapi-swagger": "17.3.2",
     "https-proxy-agent": "7.0.5",
-    "joi": "17.13.3",
+    "joi": "18.2.1",
     "mongo-locks": "3.0.2",
     "mongodb": "6.10.0",
     "mongodb-memory-server": "10.3.0",
@@ -76,6 +76,7 @@
   "overrides": {
     "@shelf/jest-mongodb": {
       "mongodb-memory-server": "10.2.0"
-    }
+    },
+    "joi": "$joi"
   }
 }

--- a/src/services/movement-create-bulk.test.js
+++ b/src/services/movement-create-bulk.test.js
@@ -14,6 +14,7 @@ import * as cdpAuditing from '@defra/cdp-auditing'
 import { AUDIT_LOGGER_TYPE, BULK_RESPONSE_STATUS } from 'waste-movement-utils'
 
 jest.mock('@hapi/hoek', () => ({
+  ...jest.requireActual('@hapi/hoek'),
   wait: jest.fn()
 }))
 

--- a/src/services/movement-update-bulk.test.js
+++ b/src/services/movement-update-bulk.test.js
@@ -16,6 +16,7 @@ import { AUDIT_LOGGER_TYPE } from 'waste-movement-utils'
 import { createBulkMovementRequest } from '../test/utils/createBulkMovementRequest.js'
 
 jest.mock('@hapi/hoek', () => ({
+  ...jest.requireActual('@hapi/hoek'),
   wait: jest.fn()
 }))
 

--- a/src/services/movement-update.test.js
+++ b/src/services/movement-update.test.js
@@ -24,6 +24,7 @@ import { AUDIT_LOGGER_TYPE } from 'waste-movement-utils'
 import * as logger from '../common/helpers/logging/logger.js'
 
 jest.mock('@hapi/hoek', () => ({
+  ...jest.requireActual('@hapi/hoek'),
   wait: jest.fn()
 }))
 


### PR DESCRIPTION
- Upgrades `hapi-swagger` to version 17.3.2.
- Updates all related dependencies in `package-lock.json` and `package.json`.
- Upgrades `@hapi` related packages and 