### PR TITLE
DWTA-220 Update error handler to use validationErrorFormatter from Wa…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "pino-pretty": "13.0.0",
         "undici": "7.24.4",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#b64729205ef14e69891c635abe56657edbd71100"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#f2e83301e099390f26f8e484ec26ecfa2b60895e"
       },
       "devDependencies": {
         "@babel/core": "7.26.9",
@@ -12332,14 +12332,11 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#b64729205ef14e69891c635abe56657edbd71100",
-      "integrity": "sha512-7t5kFzhpdFM2O9qLH0x4X7lRFa48JdNyxTxib9Ug/xKOTWmG88WkA0TYRvM56+guFlVTBdA1ueSg7rBARPCqVw==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#f2e83301e099390f26f8e484ec26ecfa2b60895e",
+      "integrity": "sha512-uOrJKwLellRq39pSNrvHYKStzj8IU9PjBwztplcIfqvUOmq5ImSlmhMvYq5UhgzMe0l36s7nsbZzo9KPDgQVxg==",
       "license": "OGL-UK-3.0",
       "engines": {
         "node": ">=22"
-      },
-      "peerDependencies": {
-        "joi": "^17.13.3"
       }
     },
     "node_modules/web-streams-polyfill": {

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.24.4",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#b64729205ef14e69891c635abe56657edbd71100"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#f2e83301e099390f26f8e484ec26ecfa2b60895e"
   },
   "devDependencies": {
     "@babel/core": "7.26.9",

--- a/src/plugins/error-handler.js
+++ b/src/plugins/error-handler.js
@@ -1,4 +1,4 @@
-import { HTTP_STATUS, getErrorCategory } from 'waste-movement-utils'
+import { HTTP_STATUS, validationErrorFormatter } from 'waste-movement-utils'
 
 export const errorHandler = {
   plugin: {
@@ -17,71 +17,19 @@ export const errorHandler = {
           response.isBoom &&
           response.output?.statusCode === HTTP_STATUS.BAD_REQUEST
         ) {
-          // Access the validation error details
-          const validationErrors = response.details
-          const unexpectedErrors = []
-          const isBulkUploadEndpoint = request.path.startsWith('/bulk/')
-
-          // Transform validation errors to the required format
-          const formattedErrors = validationErrors.map((err) => {
-            const errorType = getErrorCategory(err.type)
-
-            if (errorType === 'UnexpectedError') {
-              unexpectedErrors.push(err)
-            }
-
-            // Determine the error key
-            // For most errors, Joi provides the path (e.g., ['fieldName'])
-            // However, custom validators at the schema level don't have path context
-            let key = err.path.join('.')
-
-            // Fallback to the label
-            if (!key && err.context.label) {
-              key = err.context.label
-            }
-
-            return {
-              key,
-              errorType,
-              message: err.message
-            }
-          })
-
-          // Create the custom error format
-          let customError = {
-            validation: {
-              errors: formattedErrors
-            }
-          }
+          let customError = validationErrorFormatter(response, logger)
 
           // Re-format per-item errors for bulk upload endpoints
-          const hasPerItemErrors = formattedErrors.some((error) =>
+          const hasPerItemErrors = customError.validation.errors.some((error) =>
             /^\d+(\.|$)/.test(error.key)
           )
+          const isBulkUploadEndpoint = request.path.startsWith('/bulk/')
 
           if (isBulkUploadEndpoint && hasPerItemErrors) {
             customError = formatBulkUploadValidationErrors(
               request.payload,
               customError.validation.errors,
               logger
-            )
-          }
-
-          // Log all validation errors in a single consolidated entry
-          if (unexpectedErrors.length > 0) {
-            logger.error(
-              {
-                validationErrors: formattedErrors,
-                unexpectedErrors,
-                totalErrors: formattedErrors.length,
-                unexpectedCount: unexpectedErrors.length
-              },
-              `Validation failed with unexpected error types, mapped to UnexpectedError`
-            )
-          } else {
-            logger.error(
-              { err: formattedErrors },
-              `Validation failed ${JSON.stringify(formattedErrors)}`
             )
           }
 


### PR DESCRIPTION
Ticker [DWTA-220](https://eaflood.atlassian.net/browse/DWTA-220)

Changes:
- Update `waste-movement-utils` dependency to use the latest version
- Update `error-handler` to use `validationErrorFormatter()` from `waste-movement-utils`

[DWTA-220]: https://eaflood.atlassian.net/browse/DWTA-220?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ