### PR TITLE
DWTA-276 Update waste movement utilities to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "pino-pretty": "13.0.0",
         "undici": "7.28.0",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#dee757b63b923d995113bbf9b96fb2227bee877b"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -12200,8 +12200,8 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0",
-      "integrity": "sha512-qW3r2tc+ZasqecV84AWU7MzJtkfUQaDfhNIMyvE/7QpFXOUATk6NbZPQ/LuHbD4+eZOfMDG6TDHAwWpXCmVVzw==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#dee757b63b923d995113bbf9b96fb2227bee877b",
+      "integrity": "sha512-ZA6lc8zbD5iV7h592Hf3veH/a7kJQGbtA0j+NTofAQgwrtEH9uybygSgiK1jctWpnXpbs5ZndGR5uEH48qGFfw==",
       "license": "OGL-UK-3.0",
       "engines": {
         "node": ">=22"

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.28.0",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#eccac1a8ac8a70e8f0174ce93ac90096cf3f75c0"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#dee757b63b923d995113bbf9b96fb2227bee877b"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",


### PR DESCRIPTION
### Description
Ticket [DWTA-276](https://eaflood.atlassian.net/browse/DWTA-276)

Updated the `waste-movement-utils` library to its latest version.

[DWTA-276]: https://eaflood.atlassian.net/browse/DWTA-276?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ