### PR TITLE
DWTA-293 Store PAT Submissions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2620,6 +2620,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
+      "version": "3.15.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
     "node_modules/@istanbuljs/schema": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
@@ -6543,6 +6567,20 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/esquery": {
@@ -11354,6 +11392,13 @@
       "engines": {
         "node": ">= 10.x"
       }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/stable-hash": {
       "version": "0.0.5",

--- a/package.json
+++ b/package.json
@@ -76,7 +76,6 @@
     "@shelf/jest-mongodb": {
       "mongodb-memory-server": "10.2.0"
     },
-    "joi": "$joi",
-    "js-yaml": "4.3.0"
+    "joi": "$joi"
   }
 }

--- a/src/common/helpers/mongodb.js
+++ b/src/common/helpers/mongodb.js
@@ -7,6 +7,7 @@ let mongoConfig = config.get('mongo')
 
 const wasteInputsCollection = 'waste-inputs'
 const wasteInputsHistoryCollection = 'waste-inputs-history'
+const productionApprovalTestsCollection = 'production-approval-tests'
 
 export const mongoDb = {
   plugin: {
@@ -90,6 +91,10 @@ async function createIndexes(db) {
   await db
     .collection(wasteInputsHistoryCollection)
     .createIndex({ bulkId: 1, revision: 1 })
+
+  await db
+    .collection(productionApprovalTestsCollection)
+    .createIndex({ clientId: 1 })
 }
 
 async function addSchemaValidation(db, collection) {

--- a/src/domain/productionApprovalTest.js
+++ b/src/domain/productionApprovalTest.js
@@ -1,0 +1,5 @@
+export class ProductionApprovalTest {
+  clientId
+  createdAt
+  results
+}

--- a/src/routes/production-approval-tests.js
+++ b/src/routes/production-approval-tests.js
@@ -3,6 +3,8 @@ import { handleRouteError } from '../common/helpers/bulk-route-helpers.js'
 import { ValidationError } from '../common/helpers/errors/validation-error.js'
 import { productionApprovalTestsSchema } from '../schemas/production-approval-tests.js'
 import { runProductionApprovalTests } from '../services/production-approval-tests/run-production-approval-tests.js'
+import { createProductionApprovalTest } from '../services/production-approval-test-create.js'
+import { headersSchema } from '../schemas/headers.js'
 
 const productionApprovalTests = {
   method: 'POST',
@@ -11,12 +13,13 @@ const productionApprovalTests = {
     tags: ['production-approval-tests'],
     description: 'Run one or more production approval tests',
     validate: {
-      payload: productionApprovalTestsSchema
+      payload: productionApprovalTestsSchema,
+      headers: headersSchema
     }
   },
   handler: async (request, h) => {
     try {
-      const { db, payload } = request
+      const { db, payload, headers } = request
       const payloadWasteTrackingIds = payload.map(
         ({ wasteTrackingId }) => wasteTrackingId
       )
@@ -50,9 +53,14 @@ const productionApprovalTests = {
         wasteInput: wasteInputs.get(payloadItem.wasteTrackingId)
       }))
 
-      const response = runProductionApprovalTests(productionApprovalTestData)
+      const results = runProductionApprovalTests(productionApprovalTestData)
+      const { submissionId } = await createProductionApprovalTest(
+        db,
+        headers['x-dwt-client-id'],
+        results
+      )
 
-      return h.response(response).code(HTTP_STATUS.OK)
+      return h.response({ submissionId, results }).code(HTTP_STATUS.OK)
     } catch (error) {
       return handleRouteError(h, error)
     }

--- a/src/routes/production-approval-tests.js
+++ b/src/routes/production-approval-tests.js
@@ -53,14 +53,16 @@ const productionApprovalTests = {
         wasteInput: wasteInputs.get(payloadItem.wasteTrackingId)
       }))
 
-      const results = runProductionApprovalTests(productionApprovalTestData)
+      const testResults = runProductionApprovalTests(productionApprovalTestData)
       const { submissionId } = await createProductionApprovalTest(
         db,
         headers['x-dwt-client-id'],
-        results
+        testResults
       )
 
-      return h.response({ submissionId, results }).code(HTTP_STATUS.OK)
+      return h
+        .response({ submissionId, results: testResults })
+        .code(HTTP_STATUS.OK)
     } catch (error) {
       return handleRouteError(h, error)
     }

--- a/src/routes/production-approval-tests.test.js
+++ b/src/routes/production-approval-tests.test.js
@@ -22,6 +22,7 @@ import {
   userBasicAuthTest1
 } from '../test/data/basic-auth.js'
 import { createServer } from '../server.js'
+import { createTestMongoDb } from '../test/create-test-mongo-db.js'
 
 jest.mock('@defra/cdp-auditing', () => ({
   audit: jest.fn().mockReturnValue(true)
@@ -30,14 +31,27 @@ jest.mock('@defra/cdp-auditing', () => ({
 describe('Production Approval Tests Route Tests', () => {
   let server
   let payload
+  let mongoClient
+  let testMongoDb
+  let replicaSet
+  let mongoUri
 
   const traceId = 'created-trace-id-123'
+  const clientId = 'client-id-123'
 
   beforeEach(() => {
     payload = JSON.parse(JSON.stringify(productionApprovalTestsRequestPayload))
   })
 
   beforeAll(async () => {
+    const testMongo = await createTestMongoDb(true)
+    mongoClient = testMongo.client
+    testMongoDb = testMongo.db
+    mongoUri = testMongo.mongoUri
+    replicaSet = testMongo.replicaSet
+
+    config.set('mongo.uri', mongoUri)
+    config.set('mongo.readPreference', 'primary')
     config.set('orgApiCodes', base64EncodedOrgApiCodes)
 
     process.env.ACCESS_CRED_TEST1 = userBasicAuthTest1
@@ -85,8 +99,16 @@ describe('Production Approval Tests Route Tests', () => {
     expect(createR02TestData.result).toEqual(null)
   })
 
+  beforeEach(async () => {
+    await testMongoDb.collection('production-approval-tests').deleteMany({})
+  })
+
   afterAll(async () => {
+    if (replicaSet) {
+      await replicaSet.stop()
+    }
     await server.stop()
+    await mongoClient.close()
   })
 
   it('runs production approval tests when given a valid payload', async () => {
@@ -96,25 +118,33 @@ describe('Production Approval Tests Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
 
+    const createdProductionApprovalTest = await testMongoDb
+      .collection('production-approval-tests')
+      .findOne({ clientId })
+
     expect(statusCode).toEqual(HTTP_STATUS.OK)
-    expect(result).toEqual([
-      {
-        scenarioId: payload[0].scenarioId,
-        wasteTrackingId: payload[0].wasteTrackingId,
-        status: 'Pass',
-        message: ''
-      },
-      {
-        scenarioId: payload[1].scenarioId,
-        wasteTrackingId: payload[1].wasteTrackingId,
-        status: 'Pass',
-        message: ''
-      }
-    ])
+    expect(result).toEqual({
+      submissionId: createdProductionApprovalTest._id,
+      results: [
+        {
+          scenarioId: payload[0].scenarioId,
+          wasteTrackingId: payload[0].wasteTrackingId,
+          status: 'Pass',
+          message: ''
+        },
+        {
+          scenarioId: payload[1].scenarioId,
+          wasteTrackingId: payload[1].wasteTrackingId,
+          status: 'Pass',
+          message: ''
+        }
+      ]
+    })
   })
 
   it('runs production approval tests when given a valid payload with duplicate waste tracking ids', async () => {
@@ -132,31 +162,39 @@ describe('Production Approval Tests Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
 
+    const createdProductionApprovalTest = await testMongoDb
+      .collection('production-approval-tests')
+      .findOne({ clientId })
+
     expect(statusCode).toEqual(HTTP_STATUS.OK)
-    expect(result).toEqual([
-      {
-        scenarioId: payload[0].scenarioId,
-        wasteTrackingId: payload[0].wasteTrackingId,
-        status: 'Pass',
-        message: ''
-      },
-      {
-        scenarioId: payload[1].scenarioId,
-        wasteTrackingId: payload[1].wasteTrackingId,
-        status: 'Pass',
-        message: ''
-      },
-      {
-        scenarioId: payload[2].scenarioId,
-        wasteTrackingId: payload[2].wasteTrackingId,
-        status: 'Pass',
-        message: ''
-      }
-    ])
+    expect(result).toEqual({
+      submissionId: createdProductionApprovalTest._id,
+      results: [
+        {
+          scenarioId: payload[0].scenarioId,
+          wasteTrackingId: payload[0].wasteTrackingId,
+          status: 'Pass',
+          message: ''
+        },
+        {
+          scenarioId: payload[1].scenarioId,
+          wasteTrackingId: payload[1].wasteTrackingId,
+          status: 'Pass',
+          message: ''
+        },
+        {
+          scenarioId: payload[2].scenarioId,
+          wasteTrackingId: payload[2].wasteTrackingId,
+          status: 'Pass',
+          message: ''
+        }
+      ]
+    })
   })
 
   it('returns a 400 error when given waste tracking ids that do not exist', async () => {
@@ -181,6 +219,7 @@ describe('Production Approval Tests Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -216,6 +255,7 @@ describe('Production Approval Tests Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -250,6 +290,7 @@ describe('Production Approval Tests Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })

--- a/src/schemas/headers.js
+++ b/src/schemas/headers.js
@@ -1,0 +1,13 @@
+import Joi from 'joi'
+
+const joiHeaders = Joi.defaults((schema) =>
+  schema.options({
+    allowUnknown: true
+  })
+)
+
+export const headersSchema = joiHeaders
+  .object({
+    'x-dwt-client-id': Joi.string().required()
+  })
+  .messages({ 'any.required': '{{ #label }} is a required header' })

--- a/src/schemas/headers.test.js
+++ b/src/schemas/headers.test.js
@@ -1,0 +1,48 @@
+import { headersSchema } from './headers.js'
+
+describe('headersSchema', () => {
+  const headers = { 'x-dwt-client-id': 'client-id-123' }
+
+  it('should accept when given valid headers', () => {
+    const { error } = headersSchema.validate(headers)
+
+    expect(error).toBeUndefined()
+  })
+
+  it('should accept when given an unknown field', () => {
+    headers['x-cdp-request-id'] = 'trace-id-123'
+
+    const { error } = headersSchema.validate(headers)
+
+    expect(error).toBeUndefined()
+  })
+
+  it('should reject when client id is undefined', () => {
+    headers['x-dwt-client-id'] = undefined
+
+    const { error } = headersSchema.validate(headers)
+
+    expect(error).toBeDefined()
+    expect(error.message).toEqual('"x-dwt-client-id" is a required header')
+  })
+
+  it('should reject when client id is an empty string', () => {
+    headers['x-dwt-client-id'] = ''
+
+    const { error } = headersSchema.validate(headers)
+
+    expect(error).toBeDefined()
+    expect(error.message).toEqual(
+      '"x-dwt-client-id" is not allowed to be empty'
+    )
+  })
+
+  it('should reject when client id is null', () => {
+    headers['x-dwt-client-id'] = null
+
+    const { error } = headersSchema.validate(headers)
+
+    expect(error).toBeDefined()
+    expect(error.message).toEqual('"x-dwt-client-id" must be a string')
+  })
+})

--- a/src/services/production-approval-test-create.js
+++ b/src/services/production-approval-test-create.js
@@ -48,34 +48,50 @@ export async function createProductionApprovalTest(db, clientId, results) {
   }
 }
 
+/**
+ * Builds a summary of Production Approval Test results
+ *
+ * @param {Array} results - The Production Approval Test results
+ *
+ * @returns {Object} The Production Approval Test summary
+ */
 export function buildProductionApprovalTestResultsSummary(results) {
   if (!Array.isArray(results)) {
-    throw new Error(
+    throw new TypeError(
       `buildProductionApprovalTestResultsSummary() expected 'results' to be array but instead got '${typeof results}'`
     )
   }
 
   return results.reduce(
-    (info, result) => {
-      info.totalPassed += result.status === PAT_STATUS.PASS ? 1 : 0
-      info.totalFailed += result.status === PAT_STATUS.FAIL ? 1 : 0
-      info.results[result.scenarioId] = result
-      return info
+    (summary, result) => {
+      summary.totalPassed += result.status === PAT_STATUS.PASS ? 1 : 0
+      summary.totalFailed += result.status === PAT_STATUS.FAIL ? 1 : 0
+      summary.results[result.scenarioId] = result
+      return summary
     },
     {
       total: productionApprovalTestScenarioIds.length,
       totalSubmitted: results.length,
       totalPassed: 0,
       totalFailed: 0,
-      results: buildDefaultResultsObject(productionApprovalTestScenarioIds)
+      results: buildDefaultProductionApprovalTestResultsObject(
+        productionApprovalTestScenarioIds
+      )
     }
   )
 }
 
-export function buildDefaultResultsObject(results) {
+/**
+ * Builds a default Production Approval Test results object
+ *
+ * @param {Array} results - The Production Approval Test results
+ *
+ * @returns {Object} The Production Approval Test results object
+ */
+export function buildDefaultProductionApprovalTestResultsObject(results) {
   if (!Array.isArray(results)) {
-    throw new Error(
-      `buildDefaultResultsObject() expected 'results' to be array but instead got '${typeof results}'`
+    throw new TypeError(
+      `buildDefaultProductionApprovalTestResultsObject() expected 'results' to be array but instead got '${typeof results}'`
     )
   }
 

--- a/src/services/production-approval-test-create.js
+++ b/src/services/production-approval-test-create.js
@@ -1,0 +1,91 @@
+import { productionApprovalTestScenarioIds } from 'waste-movement-utils'
+import { createLogger } from '../common/helpers/logging/logger.js'
+import { metricsCounter } from '../common/helpers/metrics.js'
+import { ProductionApprovalTest } from '../domain/productionApprovalTest.js'
+import { PAT_STATUS } from '../services/production-approval-tests/status.js'
+
+const logger = createLogger()
+
+export async function createProductionApprovalTest(db, clientId, results) {
+  try {
+    const resultsSummary = buildProductionApprovalTestResultsSummary(results)
+
+    const productionApprovalTest = new ProductionApprovalTest()
+    productionApprovalTest.clientId = clientId
+    productionApprovalTest.createdAt = new Date()
+    productionApprovalTest.results = Object.values(resultsSummary.results)
+
+    const insertedId = await db
+      .collection('production-approval-tests')
+      .insertOne(productionApprovalTest)
+      .then((result) => result?.insertedId)
+
+    if (!insertedId) {
+      throw new Error('Inserted id is undefined')
+    }
+
+    const metricsDimensions = {
+      createdAt: productionApprovalTest.createdAt,
+      clientId,
+      totalScenarios: resultsSummary.total,
+      totalScenariosSubmitted: resultsSummary.totalSubmitted,
+      totalScenariosPassed: resultsSummary.totalPassed,
+      totalScenariosFailed: resultsSummary.totalFailed
+    }
+
+    Object.values(resultsSummary.results).forEach((result) => {
+      metricsDimensions[`status${result.scenarioId}`] = result.status
+    })
+
+    await metricsCounter('productionApprovalTest.create', 1, metricsDimensions)
+
+    return { submissionId: insertedId }
+  } catch (error) {
+    logger.error({ error }, 'Failed to create production approval test')
+    throw new Error(
+      `Failed to create production approval test: ${error.message}`
+    )
+  }
+}
+
+export function buildProductionApprovalTestResultsSummary(results) {
+  if (!Array.isArray(results)) {
+    throw new Error(
+      `buildProductionApprovalTestResultsSummary() expected 'results' to be array but instead got '${typeof results}'`
+    )
+  }
+
+  return results.reduce(
+    (info, result) => {
+      info.totalPassed += result.status === PAT_STATUS.PASS ? 1 : 0
+      info.totalFailed += result.status === PAT_STATUS.FAIL ? 1 : 0
+      info.results[result.scenarioId] = result
+      return info
+    },
+    {
+      total: productionApprovalTestScenarioIds.length,
+      totalSubmitted: results.length,
+      totalPassed: 0,
+      totalFailed: 0,
+      results: buildDefaultResultsObject(productionApprovalTestScenarioIds)
+    }
+  )
+}
+
+export function buildDefaultResultsObject(results) {
+  if (!Array.isArray(results)) {
+    throw new Error(
+      `buildDefaultResultsObject() expected 'results' to be array but instead got '${typeof results}'`
+    )
+  }
+
+  return results.reduce((status, scenarioId) => {
+    status[scenarioId] = {
+      scenarioId,
+      wasteTrackingId: '',
+      status: PAT_STATUS.NOT_SUBMITTED,
+      message: ''
+    }
+    return status
+  }, {})
+}

--- a/src/services/production-approval-test-create.test.js
+++ b/src/services/production-approval-test-create.test.js
@@ -1,6 +1,6 @@
 import { createTestMongoDb } from '../test/create-test-mongo-db.js'
 import {
-  buildDefaultResultsObject,
+  buildDefaultProductionApprovalTestResultsObject,
   createProductionApprovalTest,
   buildProductionApprovalTestResultsSummary
 } from './production-approval-test-create.js'
@@ -119,7 +119,7 @@ describe('production-approval-test-create', () => {
         })
       }
 
-      expect(() =>
+      await expect(() =>
         createProductionApprovalTest(mockDb, clientId, testResultData)
       ).rejects.toThrowError(
         'Failed to create production approval test: Inserted id is undefined'
@@ -159,7 +159,11 @@ describe('production-approval-test-create', () => {
         totalFailed: 5,
         results: {
           ...productionApprovalTestsResults,
-          ...buildDefaultResultsObject(['R01', 'R02', 'R03'])
+          ...buildDefaultProductionApprovalTestResultsObject([
+            'R01',
+            'R02',
+            'R03'
+          ])
         }
       })
     })
@@ -172,7 +176,9 @@ describe('production-approval-test-create', () => {
         totalSubmitted: 0,
         totalPassed: 0,
         totalFailed: 0,
-        results: buildDefaultResultsObject(productionApprovalTestScenarioIds)
+        results: buildDefaultProductionApprovalTestResultsObject(
+          productionApprovalTestScenarioIds
+        )
       })
     })
 
@@ -187,9 +193,13 @@ describe('production-approval-test-create', () => {
     })
   })
 
-  describe('#buildDefaultResultsObject', () => {
+  describe('#buildDefaultProductionApprovalTestResultsObject', () => {
     it('should return the correct results when given scenario ids', () => {
-      const result = buildDefaultResultsObject(['R01', 'R02', 'R03'])
+      const result = buildDefaultProductionApprovalTestResultsObject([
+        'R01',
+        'R02',
+        'R03'
+      ])
 
       expect(result).toEqual({
         R01: {
@@ -215,9 +225,11 @@ describe('production-approval-test-create', () => {
 
     it('should throw an error when not given an array', () => {
       expect(() =>
-        buildDefaultResultsObject(productionApprovalTestsResults)
+        buildDefaultProductionApprovalTestResultsObject(
+          productionApprovalTestsResults
+        )
       ).toThrowError(
-        `buildDefaultResultsObject() expected 'results' to be array but instead got 'object'`
+        `buildDefaultProductionApprovalTestResultsObject() expected 'results' to be array but instead got 'object'`
       )
     })
   })

--- a/src/services/production-approval-test-create.test.js
+++ b/src/services/production-approval-test-create.test.js
@@ -1,0 +1,224 @@
+import { createTestMongoDb } from '../test/create-test-mongo-db.js'
+import {
+  buildDefaultResultsObject,
+  createProductionApprovalTest,
+  buildProductionApprovalTestResultsSummary
+} from './production-approval-test-create.js'
+import { productionApprovalTestsResults } from '../test/data/production-approval-tests.js'
+import { ObjectId } from 'mongodb'
+import * as metrics from '../common/helpers/metrics.js'
+import { productionApprovalTestScenarioIds } from 'waste-movement-utils'
+import { PAT_STATUS } from './production-approval-tests/status.js'
+
+describe('production-approval-test-create', () => {
+  // Remove R01, R02 and R03 from the results so these results will be in a 'Not Submitted' state
+  const testResultData = Object.values(productionApprovalTestsResults).slice(3)
+
+  describe('#createProductionApprovalTest', () => {
+    let client
+    let db
+    let productionApprovalTestsCollection
+
+    const clientId = 'client-id-123'
+
+    beforeAll(async () => {
+      const testMongo = await createTestMongoDb()
+      client = testMongo.client
+      db = testMongo.db
+    })
+
+    afterAll(async () => {
+      await client.close()
+    })
+
+    beforeEach(async () => {
+      productionApprovalTestsCollection = db.collection(
+        'production-approval-tests'
+      )
+
+      await productionApprovalTestsCollection.deleteMany({})
+    })
+
+    it('should create a production approval test and return the inserted id', async () => {
+      const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
+
+      const result = await createProductionApprovalTest(
+        db,
+        clientId,
+        testResultData
+      )
+
+      const createdProductionApprovalTest =
+        await productionApprovalTestsCollection.findOne({
+          clientId
+        })
+
+      expect(result).toEqual({
+        submissionId: createdProductionApprovalTest._id
+      })
+
+      expect(createdProductionApprovalTest).toMatchObject({
+        _id: expect.any(ObjectId),
+        clientId,
+        createdAt: expect.any(Date),
+        results: [
+          {
+            message: '',
+            scenarioId: 'R01',
+            status: 'Not Submitted',
+            wasteTrackingId: ''
+          },
+          {
+            message: '',
+            scenarioId: 'R02',
+            status: 'Not Submitted',
+            wasteTrackingId: ''
+          },
+          {
+            message: '',
+            scenarioId: 'R03',
+            status: 'Not Submitted',
+            wasteTrackingId: ''
+          },
+          ...testResultData
+        ]
+      })
+
+      expect(metricsCounterSpy).toHaveBeenCalledWith(
+        'productionApprovalTest.create',
+        1,
+        {
+          createdAt: createdProductionApprovalTest.createdAt,
+          clientId,
+          totalScenarios: 12,
+          totalScenariosSubmitted: 9,
+          totalScenariosPassed: 4,
+          totalScenariosFailed: 5,
+          statusB01: 'Fail',
+          statusC02: 'Pass',
+          statusH01: 'Fail',
+          statusH03: 'Pass',
+          statusP01: 'Pass',
+          statusR01: 'Not Submitted',
+          statusR02: 'Not Submitted',
+          statusR03: 'Not Submitted',
+          statusR04: 'Fail',
+          statusR05: 'Fail',
+          statusR07: 'Pass',
+          statusX01: 'Fail'
+        }
+      )
+    })
+
+    it('should throw an error if inserted id is undefined', async () => {
+      const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
+
+      const mockDb = {
+        collection: () => ({
+          insertOne: jest.fn().mockResolvedValue(undefined)
+        })
+      }
+
+      expect(() =>
+        createProductionApprovalTest(mockDb, clientId, testResultData)
+      ).rejects.toThrowError(
+        'Failed to create production approval test: Inserted id is undefined'
+      )
+
+      expect(metricsCounterSpy).not.toHaveBeenCalled()
+    })
+
+    it('should handle database errors', async () => {
+      const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
+
+      const mockDb = {
+        collection: jest.fn().mockImplementation(() => {
+          throw mockError
+        })
+      }
+      const mockError = new Error('Database error')
+
+      await expect(
+        createProductionApprovalTest(mockDb, clientId, testResultData)
+      ).rejects.toThrow(
+        `Failed to create production approval test: ${mockError.message}`
+      )
+
+      expect(metricsCounterSpy).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('buildProductionApprovalTestResultsSummary', () => {
+    it('should return the correct summary when given results', () => {
+      const result = buildProductionApprovalTestResultsSummary(testResultData)
+
+      expect(result).toEqual({
+        total: 12,
+        totalSubmitted: 9,
+        totalPassed: 4,
+        totalFailed: 5,
+        results: {
+          ...productionApprovalTestsResults,
+          ...buildDefaultResultsObject(['R01', 'R02', 'R03'])
+        }
+      })
+    })
+
+    it('should return the default summary when not given results', () => {
+      const result = buildProductionApprovalTestResultsSummary([])
+
+      expect(result).toEqual({
+        total: 12,
+        totalSubmitted: 0,
+        totalPassed: 0,
+        totalFailed: 0,
+        results: buildDefaultResultsObject(productionApprovalTestScenarioIds)
+      })
+    })
+
+    it('should throw an error when not given an array', () => {
+      expect(() =>
+        buildProductionApprovalTestResultsSummary(
+          productionApprovalTestsResults
+        )
+      ).toThrowError(
+        `buildProductionApprovalTestResultsSummary() expected 'results' to be array but instead got 'object'`
+      )
+    })
+  })
+
+  describe('#buildDefaultResultsObject', () => {
+    it('should return the correct results when given scenario ids', () => {
+      const result = buildDefaultResultsObject(['R01', 'R02', 'R03'])
+
+      expect(result).toEqual({
+        R01: {
+          scenarioId: 'R01',
+          wasteTrackingId: '',
+          status: PAT_STATUS.NOT_SUBMITTED,
+          message: ''
+        },
+        R02: {
+          scenarioId: 'R02',
+          wasteTrackingId: '',
+          status: PAT_STATUS.NOT_SUBMITTED,
+          message: ''
+        },
+        R03: {
+          scenarioId: 'R03',
+          wasteTrackingId: '',
+          status: PAT_STATUS.NOT_SUBMITTED,
+          message: ''
+        }
+      })
+    })
+
+    it('should throw an error when not given an array', () => {
+      expect(() =>
+        buildDefaultResultsObject(productionApprovalTestsResults)
+      ).toThrowError(
+        `buildDefaultResultsObject() expected 'results' to be array but instead got 'object'`
+      )
+    })
+  })
+})

--- a/src/services/production-approval-tests/status.js
+++ b/src/services/production-approval-tests/status.js
@@ -1,7 +1,8 @@
 export const PAT_STATUS = {
   PASS: 'Pass',
   FAIL: 'Fail',
-  ERROR: 'Error'
+  ERROR: 'Error',
+  NOT_SUBMITTED: 'Not Submitted'
 }
 
 export const pass = () => ({ status: PAT_STATUS.PASS, message: '' })

--- a/src/test/data/production-approval-tests.js
+++ b/src/test/data/production-approval-tests.js
@@ -11,3 +11,83 @@ export const productionApprovalTestsRequestPayload = [
     wasteTrackingId: generateWasteTrackingId()
   }
 ]
+
+export const productionApprovalTestsResults = {
+  R01: {
+    scenarioId: 'R01',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Pass',
+    message: ''
+  },
+  R02: {
+    scenarioId: 'R02',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message: 'Expected more than 1 waste item for R02, found 1'
+  },
+  R03: {
+    scenarioId: 'R03',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message:
+      'Expected carrier.meansOfTransport to be "Road" for R03, found "Rail"'
+  },
+  R04: {
+    scenarioId: 'R04',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message:
+      'Expected no disposal or recovery codes for R04, found codes on waste item(s) at index 0'
+  },
+  R05: {
+    scenarioId: 'R05',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message:
+      'Expected at least one waste item to have multiple disposal or recovery codes for R05'
+  },
+  R07: {
+    scenarioId: 'R07',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Pass',
+    message: ''
+  },
+  C02: {
+    scenarioId: 'C02',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Pass',
+    message: ''
+  },
+  B01: {
+    scenarioId: 'B01',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message: 'No broker or dealer involvement in the movement'
+  },
+  P01: {
+    scenarioId: 'P01',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Pass',
+    message: ''
+  },
+  H01: {
+    scenarioId: 'H01',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message:
+      'Expected one or more waste items to have multiple hazardous components'
+  },
+  H03: {
+    scenarioId: 'H03',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Pass',
+    message: ''
+  },
+  X01: {
+    scenarioId: 'X01',
+    wasteTrackingId: '26BHUT6U',
+    status: 'Fail',
+    message:
+      'Expected one or more waste items to have POPs and Hazardous components'
+  }
+}


### PR DESCRIPTION
Ticket [DWTA-293](https://eaflood.atlassian.net/browse/DWTA-293)

This PR adds functionality to store PAT submissions

Changes:
- Add `x-dwt-client-id` header to receive Client Id for incoming requests
- Add header validation schema, which allows unknown fields and validates `x-dwt-client-id`
- Store PAT test submissions - Any missing scenarios (because of exclusions, for example) are added to the results and stored with a `Not Submitted` status
- Add metrics collection for each submission
- Update PAT endpoint response to include `submissionId`, which is the Mongo id of the inserted submission

[DWTA-293]: https://eaflood.atlassian.net/browse/DWTA-293?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ