### PR TITLE
DWTA-294 movement record enhancements

### DIFF
--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -98,7 +98,7 @@ jobs:
           HTTP_PROXY: http://localhost:8080
           PROXY_MODE: ${{ vars.PROXY_MODE }}
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
-          AUTH_DISABLED: ${{ secrets.AUTH_DISABLED }}
+          AUTH_DISABLED: ${{ vars.AUTH_DISABLED }}
           COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
           COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
           COGNITO_OAUTH_BASE_URL: ${{ secrets.COGNITO_OAUTH_BASE_URL }}
@@ -112,7 +112,7 @@ jobs:
           AUTH_PASSWORD_PRODUCTION_APPROVAL_TESTS: ${{ secrets.AUTH_PASSWORD_PRODUCTION_APPROVAL_TESTS }}
         run: |
           npm run test
-          # npm run test:zap-gate
+          npm run test:zap-gate
 
       - name: Generate Test Report
         if: always()

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -99,6 +99,9 @@ jobs:
           PROXY_MODE: zap
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
           AUTH_DISABLED: ${{ secrets.AUTH_DISABLED }}
+          COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
+          COGNITO_CLIENT_SECRET: ${{ secrets.COGNITO_CLIENT_SECRET }}
+          COGNITO_OAUTH_BASE_URL: ${{ secrets.COGNITO_OAUTH_BASE_URL }}
           ENVIRONMENT: ${{ vars.ENVIRONMENT }}
           API_LOGGING: true
           JIRA_BASE_URL: https://eaflood.atlassian.net/browse

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -98,7 +98,8 @@ jobs:
           HTTP_PROXY: http://localhost:8080
           PROXY_MODE: zap
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
-          AUTH_DISABLED: true
+          AUTH_DISABLED: ${{ secrets.AUTH_DISABLED }}
+          ENVIRONMENT: ${{ vars.ENVIRONMENT }}
           API_LOGGING: true
           JIRA_BASE_URL: https://eaflood.atlassian.net/browse
           PROFILE: integration

--- a/.github/workflows/check-pull-request.yml
+++ b/.github/workflows/check-pull-request.yml
@@ -96,7 +96,7 @@ jobs:
           WASTE_MOVEMENT_BACKEND_API_BASE_URL: http://waste-movement-backend:3001
           WASTE_ORGANISATION_BACKEND_API_BASE_URL: http://waste-organisation-backend:3001
           HTTP_PROXY: http://localhost:8080
-          PROXY_MODE: zap
+          PROXY_MODE: ${{ vars.PROXY_MODE }}
           ZAP_API_KEY: ${{ secrets.ZAP_API_KEY }}
           AUTH_DISABLED: ${{ secrets.AUTH_DISABLED }}
           COGNITO_CLIENT_ID: ${{ secrets.COGNITO_CLIENT_ID }}
@@ -112,7 +112,7 @@ jobs:
           AUTH_PASSWORD_PRODUCTION_APPROVAL_TESTS: ${{ secrets.AUTH_PASSWORD_PRODUCTION_APPROVAL_TESTS }}
         run: |
           npm run test
-          npm run test:zap-gate
+          # npm run test:zap-gate
 
       - name: Generate Test Report
         if: always()

--- a/src/domain/wasteInput.js
+++ b/src/domain/wasteInput.js
@@ -4,6 +4,7 @@ export class WasteInput {
   collection
   receipt
   submittingOrganisation
+  clientId
   createdAt
   lastUpdatedAt
   orgId

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -40,6 +40,7 @@ describe('Error Handler', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         authorization:
           'Basic d2FzdGUtbW92ZW1lbnQtZXh0ZXJuYWwtYXBpOjRkNWQ0OGNiLTQ1NmEtNDcwYS04ODE0LWVhZTI3NThiZTkwZA=='
       }

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -40,7 +40,6 @@ describe('Error Handler', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         authorization:
           'Basic d2FzdGUtbW92ZW1lbnQtZXh0ZXJuYWwtYXBpOjRkNWQ0OGNiLTQ1NmEtNDcwYS04ODE0LWVhZTI3NThiZTkwZA=='
       }

--- a/src/routes/create-receipt-movement.js
+++ b/src/routes/create-receipt-movement.js
@@ -49,12 +49,16 @@ const createReceiptMovement = [
         let requestOrgId
 
         const { wasteTrackingId } = request.params
-        const { submittingOrganisation, apiCode, ...movementData } =
+        const { submittingOrganisation, apiCode, clientId, ...movementData } =
           request.payload.movement
         const wasteInput = new WasteInput()
 
         wasteInput.wasteTrackingId = wasteTrackingId
         wasteInput.traceId = request.getTraceId()
+
+        if (clientId) {
+          wasteInput.clientId = clientId
+        }
 
         if (submittingOrganisation?.defraCustomerOrganisationId) {
           wasteInput.submittingOrganisation = {

--- a/src/routes/create-receipt-movement.js
+++ b/src/routes/create-receipt-movement.js
@@ -1,6 +1,5 @@
 import { createWasteInput } from '../services/movement-create.js'
 import { movementSchema } from '../schemas/movement.js'
-import { headersSchema } from '../schemas/headers.js'
 import { WasteInput } from '../domain/wasteInput.js'
 import Joi from 'joi'
 import { HTTP_STATUS, backoffOptions } from 'waste-movement-utils'
@@ -22,7 +21,6 @@ const createReceiptMovement = [
       description: 'Create a new waste input with a receipt movement',
       validate: {
         payload: movementSchema,
-        headers: headersSchema,
         params: Joi.object({
           wasteTrackingId: Joi.string().required()
         })
@@ -51,13 +49,17 @@ const createReceiptMovement = [
         let requestOrgId
 
         const { wasteTrackingId } = request.params
+        const clientId = request.headers['x-dwt-client-id']
         const { submittingOrganisation, apiCode, ...movementData } =
           request.payload.movement
         const wasteInput = new WasteInput()
 
         wasteInput.wasteTrackingId = wasteTrackingId
         wasteInput.traceId = request.getTraceId()
-        wasteInput.clientId = request.headers['x-dwt-client-id']
+
+        if (clientId) {
+          wasteInput.clientId = clientId
+        }
 
         if (submittingOrganisation?.defraCustomerOrganisationId) {
           wasteInput.submittingOrganisation = {

--- a/src/routes/create-receipt-movement.js
+++ b/src/routes/create-receipt-movement.js
@@ -1,5 +1,6 @@
 import { createWasteInput } from '../services/movement-create.js'
 import { movementSchema } from '../schemas/movement.js'
+import { headersSchema } from '../schemas/headers.js'
 import { WasteInput } from '../domain/wasteInput.js'
 import Joi from 'joi'
 import { HTTP_STATUS, backoffOptions } from 'waste-movement-utils'
@@ -21,6 +22,7 @@ const createReceiptMovement = [
       description: 'Create a new waste input with a receipt movement',
       validate: {
         payload: movementSchema,
+        headers: headersSchema,
         params: Joi.object({
           wasteTrackingId: Joi.string().required()
         })
@@ -49,16 +51,13 @@ const createReceiptMovement = [
         let requestOrgId
 
         const { wasteTrackingId } = request.params
-        const { submittingOrganisation, apiCode, clientId, ...movementData } =
+        const { submittingOrganisation, apiCode, ...movementData } =
           request.payload.movement
         const wasteInput = new WasteInput()
 
         wasteInput.wasteTrackingId = wasteTrackingId
         wasteInput.traceId = request.getTraceId()
-
-        if (clientId) {
-          wasteInput.clientId = clientId
-        }
+        wasteInput.clientId = request.headers['x-dwt-client-id']
 
         if (submittingOrganisation?.defraCustomerOrganisationId) {
           wasteInput.submittingOrganisation = {

--- a/src/routes/create-receipt-movement.js
+++ b/src/routes/create-receipt-movement.js
@@ -1,5 +1,6 @@
 import { createWasteInput } from '../services/movement-create.js'
 import { movementSchema } from '../schemas/movement.js'
+import { headersSchema } from '../schemas/headers.js'
 import { WasteInput } from '../domain/wasteInput.js'
 import Joi from 'joi'
 import { HTTP_STATUS, backoffOptions } from 'waste-movement-utils'
@@ -21,6 +22,7 @@ const createReceiptMovement = [
       description: 'Create a new waste input with a receipt movement',
       validate: {
         payload: movementSchema,
+        headers: headersSchema,
         params: Joi.object({
           wasteTrackingId: Joi.string().required()
         })
@@ -49,17 +51,13 @@ const createReceiptMovement = [
         let requestOrgId
 
         const { wasteTrackingId } = request.params
-        const clientId = request.headers['x-dwt-client-id']
         const { submittingOrganisation, apiCode, ...movementData } =
           request.payload.movement
         const wasteInput = new WasteInput()
 
         wasteInput.wasteTrackingId = wasteTrackingId
         wasteInput.traceId = request.getTraceId()
-
-        if (clientId) {
-          wasteInput.clientId = clientId
-        }
+        wasteInput.clientId = request.headers['x-dwt-client-id']
 
         if (submittingOrganisation?.defraCustomerOrganisationId) {
           wasteInput.submittingOrganisation = {

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -370,4 +370,41 @@ describe('movement Route Tests', () => {
 
     expect(statusCode).toEqual(HTTP_STATUS.UNAUTHORIZED)
   })
+
+  it('persists clientId at the top level when provided', async () => {
+    const { createWasteInput: actualFunction } = jest.requireActual(
+      '../services/movement-create.js'
+    )
+    movementCreate.createWasteInput.mockImplementation(actualFunction)
+    config.set('orgApiCodes', base64EncodedOrgApiCodes)
+    const wasteTrackingId = generateWasteTrackingId()
+    const clientId = 'test-client-id'
+    const payload = {
+      movement: {
+        ...createTestPayload(),
+        clientId
+      }
+    }
+
+    const { statusCode, result } = await server.inject({
+      method: 'POST',
+      url: `/movements/${wasteTrackingId}/receive`,
+      payload,
+      headers: {
+        'x-cdp-request-id': 'trace-client',
+        Authorization: `Basic ${requestBasicAuthTest1}`
+      }
+    })
+
+    expect(statusCode).toEqual(204)
+    expect(result).toEqual(null)
+
+    const actualWasteInput = await testMongoDb
+      .collection('waste-inputs')
+      .findOne({ _id: wasteTrackingId })
+
+    expect(actualWasteInput.clientId).toEqual(clientId)
+    // clientId is stored top-level, not nested inside the receipt movement
+    expect(actualWasteInput.receipt.movement.clientId).toBeUndefined()
+  })
 })

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -397,7 +397,7 @@ describe('movement Route Tests', () => {
     })
 
     expect(statusCode).toEqual(204)
-    expect(result).toEqual(null)
+    expect(result).toBeNull()
 
     const actualWasteInput = await testMongoDb
       .collection('waste-inputs')

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -98,6 +98,7 @@ describe('movement Route Tests', () => {
       payload: expectedPayload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -142,6 +143,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -171,6 +173,7 @@ describe('movement Route Tests', () => {
       payload: invalidPayload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -199,6 +202,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -233,6 +237,7 @@ describe('movement Route Tests', () => {
         payload,
         headers: {
           'x-cdp-request-id': traceId,
+          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         }
       })
@@ -275,6 +280,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -310,6 +316,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -344,6 +351,7 @@ describe('movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -371,15 +379,10 @@ describe('movement Route Tests', () => {
     expect(statusCode).toEqual(HTTP_STATUS.UNAUTHORIZED)
   })
 
-  it('creates a waste input when the x-dwt-client-id header is absent', async () => {
-    const { createWasteInput: actualFunction } = jest.requireActual(
-      '../services/movement-create.js'
-    )
-    movementCreate.createWasteInput.mockImplementation(actualFunction)
-    config.set('orgApiCodes', base64EncodedOrgApiCodes)
+  it('returns 400 when the x-dwt-client-id header is missing', async () => {
     const wasteTrackingId = generateWasteTrackingId()
 
-    const { statusCode, result } = await server.inject({
+    const { statusCode } = await server.inject({
       method: 'POST',
       url: `/movements/${wasteTrackingId}/receive`,
       payload: { movement: createTestPayload() },
@@ -388,13 +391,7 @@ describe('movement Route Tests', () => {
       }
     })
 
-    expect(statusCode).toEqual(HTTP_STATUS.NO_CONTENT)
-    expect(result).toBeNull()
-
-    const actualWasteInput = await testMongoDb
-      .collection('waste-inputs')
-      .findOne({ _id: wasteTrackingId })
-    expect(actualWasteInput.clientId).toBeNull()
+    expect(statusCode).toEqual(HTTP_STATUS.BAD_REQUEST)
   })
 
   it('persists clientId at the top level when provided', async () => {

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -98,7 +98,6 @@ describe('movement Route Tests', () => {
       payload: expectedPayload,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -143,7 +142,6 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -173,7 +171,6 @@ describe('movement Route Tests', () => {
       payload: invalidPayload,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -202,7 +199,6 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -237,7 +233,6 @@ describe('movement Route Tests', () => {
         payload,
         headers: {
           'x-cdp-request-id': traceId,
-          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         }
       })
@@ -280,7 +275,6 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -316,7 +310,6 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -351,7 +344,6 @@ describe('movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -379,10 +371,15 @@ describe('movement Route Tests', () => {
     expect(statusCode).toEqual(HTTP_STATUS.UNAUTHORIZED)
   })
 
-  it('returns 400 when the x-dwt-client-id header is missing', async () => {
+  it('creates a waste input when the x-dwt-client-id header is absent', async () => {
+    const { createWasteInput: actualFunction } = jest.requireActual(
+      '../services/movement-create.js'
+    )
+    movementCreate.createWasteInput.mockImplementation(actualFunction)
+    config.set('orgApiCodes', base64EncodedOrgApiCodes)
     const wasteTrackingId = generateWasteTrackingId()
 
-    const { statusCode } = await server.inject({
+    const { statusCode, result } = await server.inject({
       method: 'POST',
       url: `/movements/${wasteTrackingId}/receive`,
       payload: { movement: createTestPayload() },
@@ -391,7 +388,13 @@ describe('movement Route Tests', () => {
       }
     })
 
-    expect(statusCode).toEqual(HTTP_STATUS.BAD_REQUEST)
+    expect(statusCode).toEqual(HTTP_STATUS.NO_CONTENT)
+    expect(result).toBeNull()
+
+    const actualWasteInput = await testMongoDb
+      .collection('waste-inputs')
+      .findOne({ _id: wasteTrackingId })
+    expect(actualWasteInput.clientId).toBeNull()
   })
 
   it('persists clientId at the top level when provided', async () => {

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -98,6 +98,7 @@ describe('movement Route Tests', () => {
       payload: expectedPayload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -142,6 +143,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -171,6 +173,7 @@ describe('movement Route Tests', () => {
       payload: invalidPayload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -199,6 +202,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -233,6 +237,7 @@ describe('movement Route Tests', () => {
         payload,
         headers: {
           'x-cdp-request-id': traceId,
+          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         }
       })
@@ -275,6 +280,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -310,6 +316,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -344,6 +351,7 @@ describe('movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -371,6 +379,21 @@ describe('movement Route Tests', () => {
     expect(statusCode).toEqual(HTTP_STATUS.UNAUTHORIZED)
   })
 
+  it('returns 400 when the x-dwt-client-id header is missing', async () => {
+    const wasteTrackingId = generateWasteTrackingId()
+
+    const { statusCode } = await server.inject({
+      method: 'POST',
+      url: `/movements/${wasteTrackingId}/receive`,
+      payload: { movement: createTestPayload() },
+      headers: {
+        Authorization: `Basic ${requestBasicAuthTest1}`
+      }
+    })
+
+    expect(statusCode).toEqual(HTTP_STATUS.BAD_REQUEST)
+  })
+
   it('persists clientId at the top level when provided', async () => {
     const { createWasteInput: actualFunction } = jest.requireActual(
       '../services/movement-create.js'
@@ -381,8 +404,7 @@ describe('movement Route Tests', () => {
     const clientId = 'test-client-id'
     const payload = {
       movement: {
-        ...createTestPayload(),
-        clientId
+        ...createTestPayload()
       }
     }
 
@@ -392,6 +414,7 @@ describe('movement Route Tests', () => {
       payload,
       headers: {
         'x-cdp-request-id': 'trace-client',
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })

--- a/src/routes/production-approval-tests.test.js
+++ b/src/routes/production-approval-tests.test.js
@@ -69,7 +69,6 @@ describe('Production Approval Tests Route Tests', () => {
       url: `/movements/${productionApprovalTestsRequestPayload[0].wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: {
@@ -87,7 +86,6 @@ describe('Production Approval Tests Route Tests', () => {
       url: `/movements/${productionApprovalTestsRequestPayload[1].wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: {

--- a/src/routes/production-approval-tests.test.js
+++ b/src/routes/production-approval-tests.test.js
@@ -69,6 +69,7 @@ describe('Production Approval Tests Route Tests', () => {
       url: `/movements/${productionApprovalTestsRequestPayload[0].wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: {
@@ -86,6 +87,7 @@ describe('Production Approval Tests Route Tests', () => {
       url: `/movements/${productionApprovalTestsRequestPayload[1].wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': clientId,
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: {

--- a/src/routes/retry-audit-log-receipt-movement.test.js
+++ b/src/routes/retry-audit-log-receipt-movement.test.js
@@ -54,7 +54,6 @@ describe('Retry Audit Log Receipt Movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -70,7 +69,6 @@ describe('Retry Audit Log Receipt Movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId2,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })

--- a/src/routes/retry-audit-log-receipt-movement.test.js
+++ b/src/routes/retry-audit-log-receipt-movement.test.js
@@ -54,6 +54,7 @@ describe('Retry Audit Log Receipt Movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -69,6 +70,7 @@ describe('Retry Audit Log Receipt Movement Route Tests', () => {
       },
       headers: {
         'x-cdp-request-id': traceId2,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })

--- a/src/routes/update-receipt-movement.js
+++ b/src/routes/update-receipt-movement.js
@@ -28,7 +28,7 @@ const updateReceiptMovement = {
   handler: async (request, h) => {
     try {
       const { wasteTrackingId } = request.params
-      const { submittingOrganisation, ...movementData } =
+      const { submittingOrganisation, clientId, ...movementData } =
         request.payload.movement
 
       const existing = await request.db
@@ -65,7 +65,8 @@ const updateReceiptMovement = {
             request.mongoClient,
             request.getTraceId(),
             'receipt.movement',
-            submittingOrganisation
+            submittingOrganisation,
+            clientId
           ),
         backoffOptions(logger)
       )

--- a/src/routes/update-receipt-movement.js
+++ b/src/routes/update-receipt-movement.js
@@ -65,8 +65,7 @@ const updateReceiptMovement = {
             request.mongoClient,
             request.getTraceId(),
             'receipt.movement',
-            submittingOrganisation,
-            clientId
+            { submittingOrganisation, clientId }
           ),
         backoffOptions(logger)
       )

--- a/src/routes/update-receipt-movement.js
+++ b/src/routes/update-receipt-movement.js
@@ -1,5 +1,6 @@
 import { updateWasteInput } from '../services/movement-update.js'
 import { movementSchema } from '../schemas/movement.js'
+import { headersSchema } from '../schemas/headers.js'
 import Joi from 'joi'
 import { HTTP_STATUS, backoffOptions } from 'waste-movement-utils'
 import { updatePlugins } from './update-plugins.js'
@@ -19,6 +20,7 @@ const updateReceiptMovement = {
       'Update an existing waste input with new receipt movement data',
     validate: {
       payload: movementSchema,
+      headers: headersSchema,
       params: Joi.object({
         wasteTrackingId: Joi.string().required()
       })
@@ -28,7 +30,8 @@ const updateReceiptMovement = {
   handler: async (request, h) => {
     try {
       const { wasteTrackingId } = request.params
-      const { submittingOrganisation, clientId, ...movementData } =
+      const clientId = request.headers['x-dwt-client-id']
+      const { submittingOrganisation, ...movementData } =
         request.payload.movement
 
       const existing = await request.db

--- a/src/routes/update-receipt-movement.js
+++ b/src/routes/update-receipt-movement.js
@@ -1,6 +1,5 @@
 import { updateWasteInput } from '../services/movement-update.js'
 import { movementSchema } from '../schemas/movement.js'
-import { headersSchema } from '../schemas/headers.js'
 import Joi from 'joi'
 import { HTTP_STATUS, backoffOptions } from 'waste-movement-utils'
 import { updatePlugins } from './update-plugins.js'
@@ -20,7 +19,6 @@ const updateReceiptMovement = {
       'Update an existing waste input with new receipt movement data',
     validate: {
       payload: movementSchema,
-      headers: headersSchema,
       params: Joi.object({
         wasteTrackingId: Joi.string().required()
       })

--- a/src/routes/update-receipt-movement.js
+++ b/src/routes/update-receipt-movement.js
@@ -1,5 +1,6 @@
 import { updateWasteInput } from '../services/movement-update.js'
 import { movementSchema } from '../schemas/movement.js'
+import { headersSchema } from '../schemas/headers.js'
 import Joi from 'joi'
 import { HTTP_STATUS, backoffOptions } from 'waste-movement-utils'
 import { updatePlugins } from './update-plugins.js'
@@ -19,6 +20,7 @@ const updateReceiptMovement = {
       'Update an existing waste input with new receipt movement data',
     validate: {
       payload: movementSchema,
+      headers: headersSchema,
       params: Joi.object({
         wasteTrackingId: Joi.string().required()
       })

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -191,6 +191,33 @@ describe('movementUpdate Route Tests', () => {
     expect(historicState[1].receipt.movement).toEqual(payload.movement)
   })
 
+  it('persists clientId at the top level on update', async () => {
+    const wasteTrackingId = generateWasteTrackingId()
+    const clientId = 'test-client-id'
+
+    const createResult = await server.inject({
+      method: 'POST',
+      url: `/movements/${wasteTrackingId}/receive`,
+      headers: {
+        'x-cdp-request-id': traceId,
+        Authorization: `Basic ${requestBasicAuthTest1}`
+      },
+      payload: { movement: createTestPayload() }
+    })
+    expect(createResult.statusCode).toEqual(204)
+
+    await updateReceipt(
+      wasteTrackingId,
+      { movement: { ...createTestPayload(), clientId } },
+      traceId
+    )
+
+    const actualWasteInput = await getCurrentWasteInput(wasteTrackingId)
+    expect(actualWasteInput.clientId).toEqual(clientId)
+    // clientId is stored top-level, not nested inside the receipt movement
+    expect(actualWasteInput.receipt.movement.clientId).toBeUndefined()
+  })
+
   it('returns 404 when updating a non-existent waste input', async () => {
     const wasteTrackingId = 'nonexistent-id'
     const updatePayload = {

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -87,6 +87,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -152,6 +153,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -200,6 +202,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: { movement: createTestPayload() }
@@ -208,7 +211,7 @@ describe('movementUpdate Route Tests', () => {
 
     await updateReceipt(
       wasteTrackingId,
-      { movement: { ...createTestPayload(), clientId } },
+      { movement: { ...createTestPayload() } },
       traceId
     )
 
@@ -229,6 +232,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -255,6 +259,7 @@ describe('movementUpdate Route Tests', () => {
       payload: updatePayload,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       }
     })
@@ -280,6 +285,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -300,6 +306,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -332,6 +339,7 @@ describe('movementUpdate Route Tests', () => {
         url: `/movements/${wasteTrackingId}/receive`,
         headers: {
           'x-cdp-request-id': traceId,
+          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         },
         payload: createPayload
@@ -351,6 +359,7 @@ describe('movementUpdate Route Tests', () => {
         url: `/movements/${wasteTrackingId}/receive`,
         headers: {
           'x-cdp-request-id': traceId,
+          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         },
         payload: updatePayload
@@ -382,6 +391,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -402,6 +412,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -438,6 +449,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/nonexistent-id/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -468,6 +480,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -490,6 +503,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -528,6 +542,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -541,6 +556,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -568,6 +584,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -584,6 +601,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -87,6 +87,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -152,6 +153,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -200,6 +202,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: { movement: createTestPayload() }
@@ -229,6 +232,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -281,6 +285,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -301,6 +306,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -333,6 +339,7 @@ describe('movementUpdate Route Tests', () => {
         url: `/movements/${wasteTrackingId}/receive`,
         headers: {
           'x-cdp-request-id': traceId,
+          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         },
         payload: createPayload
@@ -352,6 +359,7 @@ describe('movementUpdate Route Tests', () => {
         url: `/movements/${wasteTrackingId}/receive`,
         headers: {
           'x-cdp-request-id': traceId,
+          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         },
         payload: updatePayload
@@ -383,6 +391,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -403,6 +412,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -439,6 +449,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/nonexistent-id/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -469,6 +480,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -491,6 +503,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -529,6 +542,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -542,6 +556,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -569,6 +584,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -585,6 +601,7 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
+        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -87,7 +87,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -153,7 +152,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -202,7 +200,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: { movement: createTestPayload() }
@@ -232,7 +229,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -285,7 +281,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -306,7 +301,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -339,7 +333,6 @@ describe('movementUpdate Route Tests', () => {
         url: `/movements/${wasteTrackingId}/receive`,
         headers: {
           'x-cdp-request-id': traceId,
-          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         },
         payload: createPayload
@@ -359,7 +352,6 @@ describe('movementUpdate Route Tests', () => {
         url: `/movements/${wasteTrackingId}/receive`,
         headers: {
           'x-cdp-request-id': traceId,
-          'x-dwt-client-id': 'test-client-id',
           Authorization: `Basic ${requestBasicAuthTest1}`
         },
         payload: updatePayload
@@ -391,7 +383,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -412,7 +403,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -449,7 +439,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/nonexistent-id/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -480,7 +469,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: createPayload
@@ -503,7 +491,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload: updatePayload
@@ -542,7 +529,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -556,7 +542,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -584,7 +569,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload
@@ -601,7 +585,6 @@ describe('movementUpdate Route Tests', () => {
       url: `/movements/${wasteTrackingId}/receive`,
       headers: {
         'x-cdp-request-id': traceId,
-        'x-dwt-client-id': 'test-client-id',
         Authorization: `Basic ${requestBasicAuthTest1}`
       },
       payload

--- a/src/schemas/movement.js
+++ b/src/schemas/movement.js
@@ -1,6 +1,14 @@
 import Joi from 'joi'
 import { receiveMovementRequestSchema } from 'waste-movement-utils'
 
+// `clientId` is the OAuth client identifier of the software provider that
+// submitted the movement. The external API resolves it from the caller's JWT
+// and injects it before forwarding, so it is not part of the shared customer
+// input schema — it is accepted here on the internal backend contract only.
 export const movementSchema = Joi.object({
-  movement: receiveMovementRequestSchema.required()
+  movement: receiveMovementRequestSchema
+    .keys({
+      clientId: Joi.string()
+    })
+    .required()
 }).label('Movement')

--- a/src/schemas/movement.js
+++ b/src/schemas/movement.js
@@ -1,14 +1,6 @@
 import Joi from 'joi'
 import { receiveMovementRequestSchema } from 'waste-movement-utils'
 
-// `clientId` is the OAuth client identifier of the software provider that
-// submitted the movement. The external API resolves it from the caller's JWT
-// and injects it before forwarding, so it is not part of the shared customer
-// input schema — it is accepted here on the internal backend contract only.
 export const movementSchema = Joi.object({
-  movement: receiveMovementRequestSchema
-    .keys({
-      clientId: Joi.string()
-    })
-    .required()
+  movement: receiveMovementRequestSchema.required()
 }).label('Movement')

--- a/src/schemas/movement.test.js
+++ b/src/schemas/movement.test.js
@@ -1,4 +1,4 @@
-import { createTestPayload } from '../schemas/test-helpers/waste-test-helpers.js'
+import { createTestPayload } from './test-helpers/waste-test-helpers.js'
 import { movementSchema } from './movement.js'
 
 describe('movementSchema', () => {
@@ -21,6 +21,19 @@ describe('movementSchema', () => {
   it('should accept valid payload with apiCode inside movement', () => {
     const payload = {
       movement: createTestPayload()
+    }
+
+    const { error } = movementSchema.validate(payload)
+
+    expect(error).toBeUndefined()
+  })
+
+  it('should accept valid payload with clientId inside movement', () => {
+    const payload = {
+      movement: {
+        ...createTestPayload(),
+        clientId: 'test-client-id'
+      }
     }
 
     const { error } = movementSchema.validate(payload)

--- a/src/schemas/movement.test.js
+++ b/src/schemas/movement.test.js
@@ -28,19 +28,6 @@ describe('movementSchema', () => {
     expect(error).toBeUndefined()
   })
 
-  it('should accept valid payload with clientId inside movement', () => {
-    const payload = {
-      movement: {
-        ...createTestPayload(),
-        clientId: 'test-client-id'
-      }
-    }
-
-    const { error } = movementSchema.validate(payload)
-
-    expect(error).toBeUndefined()
-  })
-
   it('should return an error when movement is missing', () => {
     const payload = {
       movement: undefined

--- a/src/services/movement-update.js
+++ b/src/services/movement-update.js
@@ -64,8 +64,7 @@ export async function updateWasteInput(
   mongoClient,
   traceId,
   fieldToUpdate = undefined,
-  submittingOrganisation = null,
-  clientId = null
+  { submittingOrganisation = null, clientId = null } = {}
 ) {
   const session = mongoClient.startSession()
 

--- a/src/services/movement-update.js
+++ b/src/services/movement-update.js
@@ -21,12 +21,17 @@ function buildUpdateSet(
   updateData,
   fieldToUpdate,
   submittingOrganisation,
-  traceId
+  traceId,
+  clientId
 ) {
   const updateSet = {
     ...(fieldToUpdate ? { [fieldToUpdate]: { ...updateData } } : updateData),
     lastUpdatedAt: new Date(),
     traceId
+  }
+
+  if (clientId) {
+    updateSet.clientId = clientId
   }
 
   if (submittingOrganisation?.defraCustomerOrganisationId) {
@@ -59,7 +64,8 @@ export async function updateWasteInput(
   mongoClient,
   traceId,
   fieldToUpdate = undefined,
-  submittingOrganisation = null
+  submittingOrganisation = null,
+  clientId = null
 ) {
   const session = mongoClient.startSession()
 
@@ -98,7 +104,8 @@ export async function updateWasteInput(
         updateData,
         fieldToUpdate,
         submittingOrganisation,
-        traceId
+        traceId,
+        clientId
       )
 
       result = await wasteInputsCollection.updateOne(

--- a/src/services/movement-update.js
+++ b/src/services/movement-update.js
@@ -27,11 +27,8 @@ function buildUpdateSet(
   const updateSet = {
     ...(fieldToUpdate ? { [fieldToUpdate]: { ...updateData } } : updateData),
     lastUpdatedAt: new Date(),
-    traceId
-  }
-
-  if (clientId) {
-    updateSet.clientId = clientId
+    traceId,
+    clientId
   }
 
   if (submittingOrganisation?.defraCustomerOrganisationId) {

--- a/src/services/movement-update.test.js
+++ b/src/services/movement-update.test.js
@@ -237,7 +237,7 @@ describe('updateWasteInput', () => {
       client,
       traceId,
       undefined,
-      updateData.submittingOrganisation
+      { submittingOrganisation: updateData.submittingOrganisation }
     )
 
     const updatedWasteInput = await wasteInputsCollection.findOne({


### PR DESCRIPTION
### Description
Ticket [DWTA-294](https://eaflood.atlassian.net/browse/DWTA-294)


This pull request introduces the following changes:
- Adds support for storing and validating the `clientId` in receipt movement updates and during waste input creation processes.
- Updates schemas, routes, services, and tests to incorporate and test the functionality of `clientId`.

[DWTA-294]: https://eaflood.atlassian.net/browse/DWTA-294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ