### PR TITLE
DWTA-290 Update waste-movement-utils to latest version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
         "pino-pretty": "13.0.0",
         "undici": "7.28.0",
         "uuid": "13.0.2",
-        "waste-movement-utils": "github:DEFRA/waste-movement-utils#88443a00c30297ca901f5b07e6f79a9aa275ac2c"
+        "waste-movement-utils": "github:DEFRA/waste-movement-utils#e7b6c1d9edd8b4388cb6fa0d4ae099acd5bd8a55"
       },
       "devDependencies": {
         "@babel/core": "7.29.7",
@@ -12361,8 +12361,8 @@
     },
     "node_modules/waste-movement-utils": {
       "version": "0.0.0",
-      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#88443a00c30297ca901f5b07e6f79a9aa275ac2c",
-      "integrity": "sha512-Zm9DN/pJTGJk3KloqKfUxRnkDZJaJg3qE0wavp7O2kewiNckgn0aoVBfgUfxX637oaVVOeuSwK0PqiM14BOeIA==",
+      "resolved": "git+ssh://git@github.com/DEFRA/waste-movement-utils.git#e7b6c1d9edd8b4388cb6fa0d4ae099acd5bd8a55",
+      "integrity": "sha512-zsAf5xBQloSFPOTLTKD+7iLl9reOFE4gtlpfA8Md15liMalxMAUNmUUHmWroM6DiTRtsgCA37Urm+F8vL7X2yQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/basic": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "pino-pretty": "13.0.0",
     "undici": "7.28.0",
     "uuid": "13.0.2",
-    "waste-movement-utils": "github:DEFRA/waste-movement-utils#88443a00c30297ca901f5b07e6f79a9aa275ac2c"
+    "waste-movement-utils": "github:DEFRA/waste-movement-utils#e7b6c1d9edd8b4388cb6fa0d4ae099acd5bd8a55"
   },
   "devDependencies": {
     "@babel/core": "7.29.7",


### PR DESCRIPTION
Ticket [DWTA-290](https://eaflood.atlassian.net/browse/DWTA-290)

This PR updates `waste-movement-backend` to the latest version, which adds new Receiver Authorisation Number validation formats of `EPR/XX9999XX/D99999` and `XX9999XX/D99999`

[DWTA-290]: https://eaflood.atlassian.net/browse/DWTA-290?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ