### PR TITLE
DWTA-297 PAT check endpoint: events, metric, dashboard

### DIFF
--- a/src/services/production-approval-test-create.js
+++ b/src/services/production-approval-test-create.js
@@ -2,7 +2,7 @@ import { productionApprovalTestScenarioIds } from 'waste-movement-utils'
 import { createLogger } from '../common/helpers/logging/logger.js'
 import { metricsCounter } from '../common/helpers/metrics.js'
 import { ProductionApprovalTest } from '../domain/productionApprovalTest.js'
-import { PAT_STATUS } from '../services/production-approval-tests/status.js'
+import { PAT_STATUS } from './production-approval-tests/status.js'
 
 const logger = createLogger()
 
@@ -25,7 +25,6 @@ export async function createProductionApprovalTest(db, clientId, results) {
     }
 
     const metricsDimensions = {
-      createdAt: productionApprovalTest.createdAt,
       clientId,
       totalScenarios: resultsSummary.total,
       totalScenariosSubmitted: resultsSummary.totalSubmitted,
@@ -37,7 +36,20 @@ export async function createProductionApprovalTest(db, clientId, results) {
       metricsDimensions[`status${result.scenarioId}`] = result.status
     })
 
-    await metricsCounter('productionApprovalTest.create', 1, metricsDimensions)
+    // CloudWatch only returns a metric when queried with its full dimension
+    // set, so the dashboard metrics are emitted separately at low cardinality.
+    // Dashboards aggregate across clientId via SEARCH() wildcards.
+    await Promise.all([
+      metricsCounter('productionApprovalTest.create', 1, metricsDimensions),
+      metricsCounter('pat.submissions', 1, { clientId }),
+      ...Object.values(resultsSummary.results).map((result) =>
+        metricsCounter('pat.scenario.result', 1, {
+          clientId,
+          scenario: result.scenarioId,
+          result: result.status
+        })
+      )
+    ])
 
     return { submissionId: insertedId }
   } catch (error) {

--- a/src/services/production-approval-test-create.test.js
+++ b/src/services/production-approval-test-create.test.js
@@ -84,11 +84,15 @@ describe('production-approval-test-create', () => {
         ]
       })
 
+      // The submission summary and count metrics, plus one per scenario
+      expect(metricsCounterSpy).toHaveBeenCalledTimes(
+        2 + productionApprovalTestScenarioIds.length
+      )
+
       expect(metricsCounterSpy).toHaveBeenCalledWith(
         'productionApprovalTest.create',
         1,
         {
-          createdAt: createdProductionApprovalTest.createdAt,
           clientId,
           totalScenarios: 12,
           totalScenariosSubmitted: 9,
@@ -108,6 +112,29 @@ describe('production-approval-test-create', () => {
           statusX01: 'Fail'
         }
       )
+
+      expect(metricsCounterSpy).toHaveBeenCalledWith('pat.submissions', 1, {
+        clientId
+      })
+
+      expect(metricsCounterSpy).toHaveBeenCalledWith('pat.scenario.result', 1, {
+        clientId,
+        scenario: 'C02',
+        result: PAT_STATUS.PASS
+      })
+
+      expect(metricsCounterSpy).toHaveBeenCalledWith('pat.scenario.result', 1, {
+        clientId,
+        scenario: 'B01',
+        result: PAT_STATUS.FAIL
+      })
+
+      // Scenarios absent from the submission are still reported
+      expect(metricsCounterSpy).toHaveBeenCalledWith('pat.scenario.result', 1, {
+        clientId,
+        scenario: 'R01',
+        result: PAT_STATUS.NOT_SUBMITTED
+      })
     })
 
     it('should throw an error if inserted id is undefined', async () => {


### PR DESCRIPTION
### Description
Ticket [DWTA-297](https://eaflood.atlassian.net/browse/DWTA-297)

- Added individual metrics for submission summaries and per-scenario results.
- Removed unnecessary `createdAt` property from metrics dimensions.
- Updated tests to verify new metrics emission and validate scenarios.

[DWTA-297]: https://eaflood.atlassian.net/browse/DWTA-297?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ