### PR TITLE
DWTA-354 Add new fields into the logging

### DIFF
--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -166,11 +166,16 @@ function collectMetricsAndLogs(createdMovements) {
         wasteInput.submittingOrganisation.defraCustomerOrganisationId
       metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
       metricsCounter('receiver.orgId.bulk', 1, { orgId })
-      // Structured organisation.id field so the OpenSearch dashboards can
-      // aggregate on it (DWTA-354). clientId is intentionally absent for
-      // the bulk API.
+      // CDP's log pipeline only indexes its allowlisted ECS fields, so the
+      // organisation id rides in event.reference (DWTA-354). tenant.id (the
+      // client id) is intentionally absent for the bulk API.
       logger.info(
-        { organisation: { id: orgId } },
+        {
+          event: {
+            reference: orgId,
+            action: 'bulk-receipt-movement-created'
+          }
+        },
         'Bulk receipt movement created'
       )
     })

--- a/src/routes/create-bulk-receipt-movement.test.js
+++ b/src/routes/create-bulk-receipt-movement.test.js
@@ -19,11 +19,21 @@ const assertOrgIdWasLogged = (loggerInfoSpy) => {
   )
   expect(orgIdLogs).toEqual([
     [
-      { organisation: { id: 'fd98d4ef34e33b34fc8fad03f8c385' } },
+      {
+        event: {
+          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
+          action: 'bulk-receipt-movement-created'
+        }
+      },
       'Bulk receipt movement created'
     ],
     [
-      { organisation: { id: 'fd98d4ef34e33b34fc8fad03f8c385' } },
+      {
+        event: {
+          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
+          action: 'bulk-receipt-movement-created'
+        }
+      },
       'Bulk receipt movement created'
     ]
   ])

--- a/src/routes/update-bulk-receipt-movement.js
+++ b/src/routes/update-bulk-receipt-movement.js
@@ -121,12 +121,15 @@ function collectMetricsAndLogs(movements, wasteInputsToUpdate) {
   movements.forEach((_, index) => {
     metricsCounter('receipts.received.bulk', 1, { endpointType: 'put' })
     const existing = wasteInputsToUpdate[index]
+    // CDP's log pipeline only indexes its allowlisted ECS fields, so the
+    // organisation id rides in event.reference (DWTA-354).
     logger.info(
       {
-        organisation: {
-          id:
+        event: {
+          reference:
             existing.submittingOrganisation?.defraCustomerOrganisationId ??
-            existing.orgId
+            existing.orgId,
+          action: 'bulk-receipt-movement-updated'
         }
       },
       'Bulk receipt movement updated'

--- a/src/routes/update-bulk-receipt-movement.test.js
+++ b/src/routes/update-bulk-receipt-movement.test.js
@@ -24,11 +24,21 @@ const assertOrgIdWasLogged = (loggerInfoSpy) => {
   )
   expect(orgIdLogs).toEqual([
     [
-      { organisation: { id: 'fd98d4ef34e33b34fc8fad03f8c385' } },
+      {
+        event: {
+          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
+          action: 'bulk-receipt-movement-updated'
+        }
+      },
       'Bulk receipt movement updated'
     ],
     [
-      { organisation: { id: 'fd98d4ef34e33b34fc8fad03f8c385' } },
+      {
+        event: {
+          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
+          action: 'bulk-receipt-movement-updated'
+        }
+      },
       'Bulk receipt movement updated'
     ]
   ])


### PR DESCRIPTION
### Description
Ticket [DWTA-354](https://eaflood.atlassian.net/browse/DWTA-354)

Updated logging functionality to utilize `event.reference` and `event.action` fields for compatibility with ECS standards. This change enhances logging clarity and structure for bulk receipt movements.

[DWTA-354]: https://eaflood.atlassian.net/browse/DWTA-354?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ