### PR TITLE
DWTA-357 Replace metrics with logging

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,4 @@
 save-exact=true
 ignore-scripts=true
 min-release-age=7
+min-release-age-exclude[]=@defra/waste-movement-utils

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@defra/cdp-auditing": "0.5.0",
         "@defra/hapi-tracing": "1.0.0",
-        "@defra/waste-movement-utils": "1.0.0",
+        "@defra/waste-movement-utils": "1.4.0",
         "@elastic/ecs-pino-format": "1.5.0",
         "@hapi/boom": "10.0.1",
         "@hapi/hapi": "21.3.12",
@@ -53,23 +53,6 @@
         "nodemon": "3.1.7",
         "npm-run-all": "4.1.5",
         "prettier": "3.3.3"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "../waste-movement-utils": {
-      "version": "0.0.0",
-      "extraneous": true,
-      "license": "OGL-UK-3.0",
-      "devDependencies": {
-        "@babel/preset-env": "^7.29.7",
-        "babel-jest": "^30.4.1",
-        "babel-plugin-transform-import-meta": "^2.3.3",
-        "eslint": "9.39.2",
-        "jest": "30.4.2",
-        "neostandard": "0.13.0",
-        "prettier": "3.8.3"
       },
       "engines": {
         "node": ">=22"
@@ -1928,9 +1911,9 @@
       }
     },
     "node_modules/@defra/waste-movement-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@defra/waste-movement-utils/-/waste-movement-utils-1.0.0.tgz",
-      "integrity": "sha512-3ifOymb/wviOKcx8SZAu5SwpOZRjG1mhfyBdBi/pulAp/1+5jvSQ/IoIEh5Pr4oFYu7eJo76hBhd7uOpltdMqQ==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@defra/waste-movement-utils/-/waste-movement-utils-1.4.0.tgz",
+      "integrity": "sha512-rqrkC/uk05eye6lbYep8c6zf0hxCP6GIkTOGVLSnmYisUD4p77KGZox5WOU6603Yj5IFJt6GH8LETb2MeBFXIQ==",
       "license": "OGL-UK-3.0",
       "dependencies": {
         "@hapi/basic": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "@defra/cdp-auditing": "0.5.0",
     "@defra/hapi-tracing": "1.0.0",
-    "@defra/waste-movement-utils": "1.0.0",
+    "@defra/waste-movement-utils": "1.4.0",
     "@elastic/ecs-pino-format": "1.5.0",
     "@hapi/boom": "10.0.1",
     "@hapi/hapi": "21.3.12",

--- a/src/common/helpers/logging/audit-logger.js
+++ b/src/common/helpers/logging/audit-logger.js
@@ -1,6 +1,6 @@
 import { audit } from '@defra/cdp-auditing'
 import { createLogger } from './logger.js'
-import { AUDIT_LOGGER_TYPE } from '@defra/waste-movement-utils'
+import { AUDIT_LOGGER_TYPE, METRIC_NAMES } from '@defra/waste-movement-utils'
 import { metricsCounter } from '../metrics.js'
 import { config } from '../../../config.js'
 
@@ -88,6 +88,7 @@ export function auditLogger({
     )
 
     metricsCounter('audit.errors.failed', 1, { auditLogType: type, traceId })
+    logger.info(`${METRIC_NAMES.AUDIT_ERRORS_FAILED} - ${type}`)
 
     if (shouldThrowError) {
       throw new Error(logErrorMessage)

--- a/src/common/helpers/logging/audit-logger.test.js
+++ b/src/common/helpers/logging/audit-logger.test.js
@@ -1,7 +1,7 @@
 import { auditLogger } from './audit-logger.js'
 import * as cdpAuditing from '@defra/cdp-auditing'
 import * as logger from '../logging/logger.js'
-import { AUDIT_LOGGER_TYPE } from '@defra/waste-movement-utils'
+import { AUDIT_LOGGER_TYPE, METRIC_NAMES } from '@defra/waste-movement-utils'
 import * as metrics from '../metrics.js'
 import { config } from '../../../config.js'
 
@@ -80,7 +80,9 @@ describe('Audit Logger Tests', () => {
     })
 
     it('should log an error when given an invalid type', () => {
-      const errorLogSpy = jest.spyOn(logger.createLogger(), 'error')
+      const mockLogger = logger.createLogger()
+      const errorLogSpy = jest.spyOn(mockLogger, 'error')
+      const infoLogSpy = jest.spyOn(mockLogger, 'info')
       const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
 
       const result = auditLogger({
@@ -103,10 +105,15 @@ describe('Audit Logger Tests', () => {
         auditLogType: 'created',
         traceId: params.traceId
       })
+      expect(infoLogSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.AUDIT_ERRORS_FAILED} - created`
+      )
     })
 
     it('should log an error when not given data', () => {
-      const errorLogSpy = jest.spyOn(logger.createLogger(), 'error')
+      const mockLogger = logger.createLogger()
+      const errorLogSpy = jest.spyOn(mockLogger, 'error')
+      const infoLogSpy = jest.spyOn(mockLogger, 'info')
       const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
 
       const result = auditLogger({
@@ -129,10 +136,15 @@ describe('Audit Logger Tests', () => {
         auditLogType: AUDIT_LOGGER_TYPE.MOVEMENT_CREATED,
         traceId: params.traceId
       })
+      expect(infoLogSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.AUDIT_ERRORS_FAILED} - ${AUDIT_LOGGER_TYPE.MOVEMENT_CREATED}`
+      )
     })
 
     it('should log an error when not given data as an object', () => {
-      const errorLogSpy = jest.spyOn(logger.createLogger(), 'error')
+      const mockLogger = logger.createLogger()
+      const errorLogSpy = jest.spyOn(mockLogger, 'error')
+      const infoLogSpy = jest.spyOn(mockLogger, 'info')
       const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
 
       const result = auditLogger({
@@ -155,6 +167,9 @@ describe('Audit Logger Tests', () => {
         auditLogType: AUDIT_LOGGER_TYPE.MOVEMENT_CREATED,
         traceId: params.traceId
       })
+      expect(infoLogSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.AUDIT_ERRORS_FAILED} - ${AUDIT_LOGGER_TYPE.MOVEMENT_CREATED}`
+      )
     })
 
     it('should throw an error if shouldThrowError is set', () => {
@@ -168,6 +183,7 @@ describe('Audit Logger Tests', () => {
         'Failed to call audit endpoint: Audit data must be provided as an object'
       )
     })
+
     it('should call the audit endpoint when the submitting organisation is not in the excluded list', () => {
       const auditSpy = jest.spyOn(cdpAuditing, 'audit')
 

--- a/src/routes/create-bulk-receipt-movement.js
+++ b/src/routes/create-bulk-receipt-movement.js
@@ -2,7 +2,8 @@ import { WasteInput } from '../domain/wasteInput.js'
 import {
   HTTP_STATUS,
   backoffOptions,
-  BULK_RESPONSE_STATUS
+  BULK_RESPONSE_STATUS,
+  METRIC_NAMES
 } from '@defra/waste-movement-utils'
 import { backOff } from 'exponential-backoff'
 import { createBulkWasteInput } from '../services/movement-create-bulk.js'
@@ -166,17 +167,12 @@ function collectMetricsAndLogs(createdMovements) {
         wasteInput.submittingOrganisation.defraCustomerOrganisationId
       metricsCounter('receipts.received.bulk', 1, { endpointType: 'post' })
       metricsCounter('receiver.orgId.bulk', 1, { orgId })
-      // CDP's log pipeline only indexes its allowlisted ECS fields, so the
-      // organisation id rides in event.reference (DWTA-354). tenant.id (the
-      // client id) is intentionally absent for the bulk API.
+      // Specifying the org id in event.reference as it could be different for different
+      // movements in a bulk upload and this should override the default org id set for
+      // all log messages
       logger.info(
-        {
-          event: {
-            reference: orgId,
-            action: 'bulk-receipt-movement-created'
-          }
-        },
-        'Bulk receipt movement created'
+        { event: { reference: orgId } },
+        `${METRIC_NAMES.RECEIPTS_RECEIVED_BULK} - post`
       )
     })
   }

--- a/src/routes/create-bulk-receipt-movement.test.js
+++ b/src/routes/create-bulk-receipt-movement.test.js
@@ -1,6 +1,10 @@
 import { expect, describe, beforeAll, afterAll, it, jest } from '@jest/globals'
 import { createTestMongoDb } from '../test/create-test-mongo-db.js'
-import { HTTP_STATUS, BULK_RESPONSE_STATUS } from '@defra/waste-movement-utils'
+import {
+  HTTP_STATUS,
+  BULK_RESPONSE_STATUS,
+  METRIC_NAMES
+} from '@defra/waste-movement-utils'
 import * as movementCreateBulk from '../services/movement-create-bulk.js'
 import { config } from '../config.js'
 import { createBulkMovementRequest } from '../test/utils/createBulkMovementRequest.js'
@@ -14,28 +18,13 @@ import { createServer } from '../server.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
 const assertOrgIdWasLogged = (loggerInfoSpy) => {
+  const logMessage = `${METRIC_NAMES.RECEIPTS_RECEIVED_BULK} - post`
   const orgIdLogs = loggerInfoSpy.mock.calls.filter(
-    ([, message]) => message === 'Bulk receipt movement created'
+    ([, message]) => message === logMessage
   )
   expect(orgIdLogs).toEqual([
-    [
-      {
-        event: {
-          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
-          action: 'bulk-receipt-movement-created'
-        }
-      },
-      'Bulk receipt movement created'
-    ],
-    [
-      {
-        event: {
-          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
-          action: 'bulk-receipt-movement-created'
-        }
-      },
-      'Bulk receipt movement created'
-    ]
+    [{ event: { reference: 'fd98d4ef34e33b34fc8fad03f8c385' } }, logMessage],
+    [{ event: { reference: 'fd98d4ef34e33b34fc8fad03f8c385' } }, logMessage]
   ])
 }
 
@@ -243,6 +232,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       'createBulkWasteInput'
     )
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     movementCreateBulk.createBulkWasteInput
       .mockImplementationOnce(() => {
@@ -310,6 +300,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     expect(createBulkWasteInputSpy).toHaveBeenCalledTimes(3)
 
     assertMetricsCounterWasCalled(metricsCounterSpy)
+    assertOrgIdWasLogged(loggerInfoSpy)
   })
 
   it('should return existing waste tracking ids when provided with a bulk id which has already been used by the POST endpoint in the waste-inputs collection', async () => {
@@ -388,6 +379,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
 
   it('should create new waste inputs when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs collection', async () => {
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     await server.inject({
       method: 'POST',
@@ -420,10 +412,12 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     })
 
     assertMetricsCounterWasCalled(metricsCounterSpy)
+    assertOrgIdWasLogged(loggerInfoSpy)
   })
 
   it('should create new waste inputs when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs-history collection', async () => {
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     await server.inject({
       method: 'POST',
@@ -456,6 +450,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
     })
 
     assertMetricsCounterWasCalled(metricsCounterSpy)
+    assertOrgIdWasLogged(loggerInfoSpy)
   })
 
   it('can handle multiple concurrent requests with the same bulkId', async () => {
@@ -497,6 +492,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
       'createBulkWasteInput'
     )
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     movementCreateBulk.createBulkWasteInput.mockRejectedValue(
       new Error(errorMessage)
@@ -521,6 +517,7 @@ describe('Create Bulk Receipt Movement Route Tests', () => {
 
     expect(createBulkWasteInputSpy).toHaveBeenCalledTimes(3)
     expect(metricsCounterSpy).not.toHaveBeenCalled()
+    expect(loggerInfoSpy).not.toHaveBeenCalled()
   })
 
   it("throws an error when the number of waste tracking ids generated doesn't match the number of movements in the payload", async () => {

--- a/src/routes/create-receipt-movement.js
+++ b/src/routes/create-receipt-movement.js
@@ -3,7 +3,11 @@ import { movementSchema } from '../schemas/movement.js'
 import { headersSchema } from '../schemas/headers.js'
 import { WasteInput } from '../domain/wasteInput.js'
 import Joi from 'joi'
-import { HTTP_STATUS, backoffOptions } from '@defra/waste-movement-utils'
+import {
+  HTTP_STATUS,
+  METRIC_NAMES,
+  backoffOptions
+} from '@defra/waste-movement-utils'
 import { getOrgIdForApiCode } from '../common/helpers/validate-api-code.js'
 import { config } from '../config.js'
 import { backOff } from 'exponential-backoff'
@@ -11,7 +15,7 @@ import { metricsCounter } from '../common/helpers/metrics.js'
 import { handleRouteError } from '../common/helpers/bulk-route-helpers.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
-const logger = createLogger
+const logger = createLogger()
 
 const createReceiptMovement = [
   {
@@ -79,6 +83,7 @@ const createReceiptMovement = [
         )
 
         metricsCounter('receiver.orgId', 1, { orgId: requestOrgId })
+        logger.info(`${METRIC_NAMES.RECEIPTS_RECEIVED} - post`)
 
         return h.response().code(HTTP_STATUS.NO_CONTENT)
       } catch (error) {

--- a/src/routes/create-receipt-movement.test.js
+++ b/src/routes/create-receipt-movement.test.js
@@ -10,6 +10,7 @@ import {
 import { createTestMongoDb } from '../test/create-test-mongo-db.js'
 import {
   HTTP_STATUS,
+  METRIC_NAMES,
   generateWasteTrackingId
 } from '@defra/waste-movement-utils'
 import * as movementCreate from '../services/movement-create.js'
@@ -27,6 +28,7 @@ import {
   userBasicAuthTest1
 } from '../test/data/basic-auth.js'
 import { createServer } from '../server.js'
+import * as logger from '../common/helpers/logging/logger.js'
 
 jest.mock('../services/movement-create.js', () => {
   const { createWasteInput: actualFunction } = jest.requireActual(
@@ -85,6 +87,7 @@ describe('movement Route Tests', () => {
     }
     const createWasteInputSpy = jest.spyOn(movementCreate, 'createWasteInput')
     const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     movementCreate.createWasteInput
       .mockImplementationOnce(() => {
@@ -127,6 +130,9 @@ describe('movement Route Tests', () => {
     expect(metricsCounterSpy).toHaveBeenCalledWith('receiver.orgId', 1, {
       orgId: actualWasteInput.orgId
     })
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - post`
+    )
   })
 
   it('handles error when creating a waste input fails', async () => {
@@ -136,6 +142,7 @@ describe('movement Route Tests', () => {
     }
     const createWasteInputSpy = jest.spyOn(movementCreate, 'createWasteInput')
     const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     movementCreate.createWasteInput.mockRejectedValue(new Error(errorMessage))
 
@@ -160,6 +167,7 @@ describe('movement Route Tests', () => {
     expect(createWasteInputSpy).toHaveBeenCalledTimes(3)
 
     expect(metricsCounterSpy).not.toHaveBeenCalled()
+    expect(infoLoggerSpy).not.toHaveBeenCalled()
   })
 
   it('does not create waste input when validation fails', async () => {
@@ -275,6 +283,7 @@ describe('movement Route Tests', () => {
         }
       }
     }
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     const { statusCode, result } = await server.inject({
       method: 'POST',
@@ -298,6 +307,10 @@ describe('movement Route Tests', () => {
     expect(actualWasteInput.submittingOrganisation).toEqual({
       defraCustomerOrganisationId: orgId1
     })
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - post`
+    )
   })
 
   it('creates a waste input with submittingOrganisation and ignores apiCode mismatch', async () => {
@@ -311,6 +324,7 @@ describe('movement Route Tests', () => {
         }
       }
     }
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     const { statusCode, result } = await server.inject({
       method: 'POST',
@@ -334,6 +348,10 @@ describe('movement Route Tests', () => {
     expect(actualWasteInput.submittingOrganisation).toEqual({
       defraCustomerOrganisationId: orgId3
     })
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - post`
+    )
   })
 
   it('creates a waste input without submittingOrganisation', async () => {
@@ -344,6 +362,7 @@ describe('movement Route Tests', () => {
     config.set('orgApiCodes', base64EncodedOrgApiCodes)
     const wasteTrackingId = generateWasteTrackingId()
     const movement = createTestPayload()
+    const infoLoggerSpy = jest.spyOn(logger.createLogger(), 'info')
 
     const { statusCode, result } = await server.inject({
       method: 'POST',
@@ -367,6 +386,10 @@ describe('movement Route Tests', () => {
 
     expect(actualWasteInput.wasteTrackingId).toEqual(wasteTrackingId)
     expect(actualWasteInput.submittingOrganisation).toBeNull()
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - post`
+    )
   })
 
   it('should return 401 when request is unauthenticated', async () => {

--- a/src/routes/update-bulk-receipt-movement.js
+++ b/src/routes/update-bulk-receipt-movement.js
@@ -2,7 +2,8 @@ import Joi from 'joi'
 import {
   HTTP_STATUS,
   backoffOptions,
-  BULK_RESPONSE_STATUS
+  BULK_RESPONSE_STATUS,
+  METRIC_NAMES
 } from '@defra/waste-movement-utils'
 import { backOff } from 'exponential-backoff'
 import { updateBulkWasteInput } from '../services/movement-update-bulk.js'
@@ -119,20 +120,17 @@ function getOrgValidationResponse(h, payload, wasteInputsToUpdate) {
  */
 function collectMetricsAndLogs(movements, wasteInputsToUpdate) {
   movements.forEach((_, index) => {
-    metricsCounter('receipts.received.bulk', 1, { endpointType: 'put' })
     const existing = wasteInputsToUpdate[index]
-    // CDP's log pipeline only indexes its allowlisted ECS fields, so the
-    // organisation id rides in event.reference (DWTA-354).
+    const orgId =
+      existing.submittingOrganisation?.defraCustomerOrganisationId ??
+      existing.orgId
+    metricsCounter('receipts.received.bulk', 1, { endpointType: 'put' })
+    // Specifying the org id in event.reference as it could be different for different
+    // movements in a bulk upload and this should override the default org id set for
+    // all log messages
     logger.info(
-      {
-        event: {
-          reference:
-            existing.submittingOrganisation?.defraCustomerOrganisationId ??
-            existing.orgId,
-          action: 'bulk-receipt-movement-updated'
-        }
-      },
-      'Bulk receipt movement updated'
+      { event: { reference: orgId } },
+      `${METRIC_NAMES.RECEIPTS_RECEIVED_BULK} - put`
     )
   })
 }

--- a/src/routes/update-bulk-receipt-movement.test.js
+++ b/src/routes/update-bulk-receipt-movement.test.js
@@ -1,6 +1,10 @@
 import { expect, describe, beforeAll, afterAll, it, jest } from '@jest/globals'
 import { createTestMongoDb } from '../test/create-test-mongo-db.js'
-import { HTTP_STATUS, BULK_RESPONSE_STATUS } from '@defra/waste-movement-utils'
+import {
+  HTTP_STATUS,
+  BULK_RESPONSE_STATUS,
+  METRIC_NAMES
+} from '@defra/waste-movement-utils'
 import * as movementUpdateBulk from '../services/movement-update-bulk.js'
 import {
   orgId1,
@@ -19,28 +23,13 @@ import { createServer } from '../server.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
 const assertOrgIdWasLogged = (loggerInfoSpy) => {
+  const logMessage = `${METRIC_NAMES.RECEIPTS_RECEIVED_BULK} - put`
   const orgIdLogs = loggerInfoSpy.mock.calls.filter(
-    ([, message]) => message === 'Bulk receipt movement updated'
+    ([, message]) => message === logMessage
   )
   expect(orgIdLogs).toEqual([
-    [
-      {
-        event: {
-          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
-          action: 'bulk-receipt-movement-updated'
-        }
-      },
-      'Bulk receipt movement updated'
-    ],
-    [
-      {
-        event: {
-          reference: 'fd98d4ef34e33b34fc8fad03f8c385',
-          action: 'bulk-receipt-movement-updated'
-        }
-      },
-      'Bulk receipt movement updated'
-    ]
+    [{ event: { reference: 'fd98d4ef34e33b34fc8fad03f8c385' } }, logMessage],
+    [{ event: { reference: 'fd98d4ef34e33b34fc8fad03f8c385' } }, logMessage]
   ])
 }
 
@@ -212,6 +201,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
       'updateBulkWasteInput'
     )
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     payload[0].wasteItems[0].disposalOrRecoveryCodes = []
 
@@ -248,10 +238,12 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     expect(updateBulkWasteInputSpy).toHaveBeenCalledTimes(1)
 
     assertMetricsCounterWasCalled(metricsCounterSpy)
+    assertOrgIdWasLogged(loggerInfoSpy)
   })
 
   it('should return NO_MOVEMENTS_UPDATED when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs collection', async () => {
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     // Update the seed data to have revision > 1 with the update bulkId
     await wasteInputsCollection.updateMany(
@@ -276,10 +268,12 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     })
 
     expect(metricsCounterSpy).not.toHaveBeenCalled()
+    expect(loggerInfoSpy).not.toHaveBeenCalled()
   })
 
   it('should return NO_MOVEMENTS_UPDATED when provided with a bulk id which has already been used by the PUT endpoint in the waste-inputs-history collection', async () => {
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     await wasteInputsHistoryCollection.insertMany([
       {
@@ -319,10 +313,12 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     })
 
     expect(metricsCounterSpy).not.toHaveBeenCalled()
+    expect(loggerInfoSpy).not.toHaveBeenCalled()
   })
 
   it('should proceed with update when bulkId exists with revision 1 only (POST endpoint bulkId)', async () => {
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     // Seed data already has revision: 1 with createBulkId
     // Using createBulkId as the PUT bulkId - since all matches have revision: 1,
@@ -344,6 +340,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     })
 
     assertMetricsCounterWasCalled(metricsCounterSpy)
+    assertOrgIdWasLogged(loggerInfoSpy)
   })
 
   it('should return 400 when submittingOrganisation does not match and existing record has no submittingOrganisation', async () => {
@@ -433,6 +430,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     config.set('orgApiCodes', base64EncodedOrgApiCodes)
 
     const metricsCounterSpy = jest.spyOn(metricsCounter, 'metricsCounter')
+    const loggerInfoSpy = jest.spyOn(createLogger(), 'info')
 
     const apiCodeItem = createBulkMovementRequest({
       wasteTrackingId: '26E4C7Z2',
@@ -459,6 +457,7 @@ describe('Update Bulk Receipt Movement Route Tests', () => {
     expect(result.status).toEqual(BULK_RESPONSE_STATUS.MOVEMENTS_UPDATED)
 
     assertMetricsCounterWasCalled(metricsCounterSpy)
+    assertOrgIdWasLogged(loggerInfoSpy)
   })
 
   it('should return 400 when apiCode org does not match the original record', async () => {

--- a/src/routes/update-receipt-movement.js
+++ b/src/routes/update-receipt-movement.js
@@ -2,14 +2,18 @@ import { updateWasteInput } from '../services/movement-update.js'
 import { movementSchema } from '../schemas/movement.js'
 import { headersSchema } from '../schemas/headers.js'
 import Joi from 'joi'
-import { HTTP_STATUS, backoffOptions } from '@defra/waste-movement-utils'
+import {
+  HTTP_STATUS,
+  METRIC_NAMES,
+  backoffOptions
+} from '@defra/waste-movement-utils'
 import { updatePlugins } from './update-plugins.js'
 import { backOff } from 'exponential-backoff'
 import { getOrganisationValidationError } from '../common/helpers/validate-organisation.js'
 import { handleRouteError } from '../common/helpers/bulk-route-helpers.js'
 import { createLogger } from '../common/helpers/logging/logger.js'
 
-const logger = createLogger
+const logger = createLogger()
 
 const updateReceiptMovement = {
   method: 'PUT',
@@ -76,6 +80,8 @@ const updateReceiptMovement = {
       if (result instanceof Error) {
         throw result
       }
+
+      logger.info(`${METRIC_NAMES.RECEIPTS_RECEIVED} - put`)
 
       if (result.matchedCount === 0) {
         return h

--- a/src/routes/update-receipt-movement.test.js
+++ b/src/routes/update-receipt-movement.test.js
@@ -3,6 +3,7 @@ import { expect } from '@jest/globals'
 import { config } from '../config.js'
 import {
   HTTP_STATUS,
+  METRIC_NAMES,
   generateWasteTrackingId
 } from '@defra/waste-movement-utils'
 import {
@@ -17,6 +18,7 @@ import {
   userBasicAuthTest1
 } from '../test/data/basic-auth.js'
 import { createServer } from '../server.js'
+import { createLogger } from '../common/helpers/logging/logger.js'
 
 jest.mock('../services/movement-update.js', () => {
   const { updateWasteInput: actualFunction } = jest.requireActual(
@@ -83,6 +85,7 @@ describe('movementUpdate Route Tests', () => {
     const payload = {
       movement: createTestPayload()
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -136,6 +139,10 @@ describe('movementUpdate Route Tests', () => {
     expect(historicState[0].receipt.movement).toEqual(payload.movement)
 
     expect(updateWasteInputSpy).toHaveBeenCalledTimes(3)
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   async function getCurrentWasteInput(wasteTrackingId) {
@@ -149,6 +156,7 @@ describe('movementUpdate Route Tests', () => {
     const payload = {
       movement: createTestPayload()
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -193,11 +201,16 @@ describe('movementUpdate Route Tests', () => {
     expect(historicState[1].wasteTrackingId).toEqual(wasteTrackingId)
     expect(historicState[1].revision).toEqual(2)
     expect(historicState[1].receipt.movement).toEqual(payload.movement)
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('persists clientId at the top level on update', async () => {
     const wasteTrackingId = generateWasteTrackingId()
     const clientId = 'test-client-id'
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -221,6 +234,10 @@ describe('movementUpdate Route Tests', () => {
     expect(actualWasteInput.clientId).toEqual(clientId)
     // clientId is stored top-level, not nested inside the receipt movement
     expect(actualWasteInput.receipt.movement.clientId).toBeUndefined()
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('returns 404 when updating a non-existent waste input', async () => {
@@ -228,6 +245,7 @@ describe('movementUpdate Route Tests', () => {
     const updatePayload = {
       movement: createTestPayload()
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const { statusCode, result } = await server.inject({
       method: 'PUT',
@@ -252,6 +270,10 @@ describe('movementUpdate Route Tests', () => {
       .findOne({ _id: wasteTrackingId })
 
     expect(actualWasteInput).toEqual(null)
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   async function updateReceipt(wasteTrackingId, updatePayload, traceId) {
@@ -281,6 +303,7 @@ describe('movementUpdate Route Tests', () => {
     const createPayload = {
       movement: createTestPayload()
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -326,6 +349,10 @@ describe('movementUpdate Route Tests', () => {
         ]
       }
     })
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it.each([undefined, null, ''])(
@@ -335,6 +362,7 @@ describe('movementUpdate Route Tests', () => {
       const createPayload = {
         movement: createTestPayload()
       }
+      const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
       const createResult = await server.inject({
         method: 'POST',
@@ -379,6 +407,10 @@ describe('movementUpdate Route Tests', () => {
           ]
         }
       })
+
+      expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+        `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+      )
     }
   )
 
@@ -387,6 +419,7 @@ describe('movementUpdate Route Tests', () => {
     const createPayload = {
       movement: createTestPayload()
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -433,6 +466,10 @@ describe('movementUpdate Route Tests', () => {
         ]
       }
     })
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('returns 404 when submittingOrganisation is provided but waste input does not exist', async () => {
@@ -445,6 +482,7 @@ describe('movementUpdate Route Tests', () => {
         }
       }
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const { statusCode, result } = await server.inject({
       method: 'PUT',
@@ -463,6 +501,10 @@ describe('movementUpdate Route Tests', () => {
       error: 'Not Found',
       message: 'Waste input with ID nonexistent-id not found'
     })
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('rejects when submittingOrganisation does not match the original record', async () => {
@@ -476,6 +518,7 @@ describe('movementUpdate Route Tests', () => {
         }
       }
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -524,6 +567,10 @@ describe('movementUpdate Route Tests', () => {
         ]
       }
     })
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('updates a waste input with submittingOrganisation', async () => {
@@ -537,6 +584,7 @@ describe('movementUpdate Route Tests', () => {
         }
       }
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     // First create a movement with submittingOrganisation
     const createResult = await server.inject({
@@ -573,6 +621,10 @@ describe('movementUpdate Route Tests', () => {
     expect(actualWasteInput.submittingOrganisation).toEqual({
       defraCustomerOrganisationId: orgId1
     })
+
+    expect(infoLoggerSpy).toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('handles error when updating a waste input fails', async () => {
@@ -580,6 +632,7 @@ describe('movementUpdate Route Tests', () => {
     const payload = {
       movement: createTestPayload()
     }
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const createResult = await server.inject({
       method: 'POST',
@@ -616,10 +669,15 @@ describe('movementUpdate Route Tests', () => {
       message: errorMessage
     })
     expect(updateWasteInputSpy).toHaveBeenCalledTimes(3)
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 
   it('should return 401 when request is unauthenticated', async () => {
     const wasteTrackingId = generateWasteTrackingId()
+    const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
     const { statusCode } = await server.inject({
       method: 'PUT',
@@ -628,5 +686,9 @@ describe('movementUpdate Route Tests', () => {
     })
 
     expect(statusCode).toEqual(HTTP_STATUS.UNAUTHORIZED)
+
+    expect(infoLoggerSpy).not.toHaveBeenCalledWith(
+      `${METRIC_NAMES.RECEIPTS_RECEIVED} - put`
+    )
   })
 })

--- a/src/services/production-approval-test-create.js
+++ b/src/services/production-approval-test-create.js
@@ -1,4 +1,7 @@
-import { productionApprovalTestScenarioIds } from '@defra/waste-movement-utils'
+import {
+  METRIC_NAMES,
+  productionApprovalTestScenarioIds
+} from '@defra/waste-movement-utils'
 import { createLogger } from '../common/helpers/logging/logger.js'
 import { metricsCounter } from '../common/helpers/metrics.js'
 import { ProductionApprovalTest } from '../domain/productionApprovalTest.js'
@@ -32,8 +35,15 @@ export async function createProductionApprovalTest(db, clientId, results) {
       totalScenariosFailed: resultsSummary.totalFailed
     }
 
+    logger.info(
+      `${METRIC_NAMES.PAT_SUBMISSION} - scenarios: ${resultsSummary.total} - submitted: ${resultsSummary.totalSubmitted} - passed: ${resultsSummary.totalPassed} - failed: ${resultsSummary.totalFailed}`
+    )
+
     Object.values(resultsSummary.results).forEach((result) => {
       metricsDimensions[`status${result.scenarioId}`] = result.status
+      logger.info(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - ${result.scenarioId} - ${result.status}`
+      )
     })
 
     // CloudWatch only returns a metric when queried with its full dimension

--- a/src/services/production-approval-test-create.test.js
+++ b/src/services/production-approval-test-create.test.js
@@ -7,10 +7,12 @@ import {
 import { ObjectId } from 'mongodb'
 import * as metrics from '../common/helpers/metrics.js'
 import {
+  METRIC_NAMES,
   productionApprovalTestScenarioIds,
   productionApprovalTestsResults
 } from '@defra/waste-movement-utils'
 import { PAT_STATUS } from './production-approval-tests/status.js'
+import { createLogger } from '../common/helpers/logging/logger.js'
 
 describe('production-approval-test-create', () => {
   // Remove R01, R02 and R03 from the results so these results will be in a 'Not Submitted' state
@@ -43,6 +45,7 @@ describe('production-approval-test-create', () => {
 
     it('should create a production approval test and return the inserted id', async () => {
       const metricsCounterSpy = jest.spyOn(metrics, 'metricsCounter')
+      const infoLoggerSpy = jest.spyOn(createLogger(), 'info')
 
       const result = await createProductionApprovalTest(
         db,
@@ -137,6 +140,46 @@ describe('production-approval-test-create', () => {
         scenario: 'R01',
         result: PAT_STATUS.NOT_SUBMITTED
       })
+
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SUBMISSION} - scenarios: 12 - submitted: 9 - passed: 4 - failed: 5`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - R01 - ${PAT_STATUS.NOT_SUBMITTED}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - R02 - ${PAT_STATUS.NOT_SUBMITTED}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - R03 - ${PAT_STATUS.NOT_SUBMITTED}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - R04 - ${PAT_STATUS.FAIL}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - R05 - ${PAT_STATUS.FAIL}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - R07 - ${PAT_STATUS.PASS}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - C02 - ${PAT_STATUS.PASS}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - B01 - ${PAT_STATUS.FAIL}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - P01 - ${PAT_STATUS.PASS}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - H01 - ${PAT_STATUS.FAIL}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - H03 - ${PAT_STATUS.PASS}`
+      )
+      expect(infoLoggerSpy).toHaveBeenCalledWith(
+        `${METRIC_NAMES.PAT_SCENARIO_RESULT} - X01 - ${PAT_STATUS.FAIL}`
+      )
     })
 
     it('should throw an error if inserted id is undefined', async () => {


### PR DESCRIPTION
Ticket [DWTA-357](https://eaflood.atlassian.net/browse/DWTA-357)

Changes:
- Exclude `waste-movement-utils` from `min-release-age` - this is so latest versions of `waste-movement-utils` can be used immediately
- Update `waste-movement-utils` to `v1.4.0` - this adds additional metric names
- Add log messages where `metricsCounter()` is currently being called - this is because `metricsCounter()` is being replaced by logging and `metricsCounter()` calls will be removed in a future commit

The new log messages don't include Organisation or Client Ids because these will be added as a default to all log messages in a future ticket...except the bulk upload log messages which override the Organisation Id because a bulk upload may include movements from multiple Organisations.

[DWTA-357]: https://eaflood.atlassian.net/browse/DWTA-357?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ