### PR TITLE
DWTA-374 WMB returning 500 errors for malformed JSON

### DIFF
--- a/src/plugins/error-handler.js
+++ b/src/plugins/error-handler.js
@@ -3,6 +3,19 @@ import {
   validationErrorFormatter
 } from '@defra/waste-movement-utils'
 
+// Payload parse failures (e.g. malformed JSON) are Boom 400s with no Joi `details`
+const formatPayloadParseError = (response) => ({
+  validation: {
+    errors: [
+      {
+        key: 'payload',
+        errorType: 'InvalidFormat',
+        message: response.output.payload.message
+      }
+    ]
+  }
+})
+
 export const errorHandler = {
   plugin: {
     name: 'errorHandler',
@@ -20,7 +33,9 @@ export const errorHandler = {
           response.isBoom &&
           response.output?.statusCode === HTTP_STATUS.BAD_REQUEST
         ) {
-          let customError = validationErrorFormatter(response, logger)
+          let customError = Array.isArray(response.details)
+            ? validationErrorFormatter(response, logger)
+            : formatPayloadParseError(response)
 
           // Re-format per-item errors for bulk upload endpoints
           const hasPerItemErrors = customError.validation.errors.some((error) =>

--- a/src/plugins/error-handler.test.js
+++ b/src/plugins/error-handler.test.js
@@ -320,6 +320,72 @@ describe('Error Handler', () => {
     })
   })
 
+  describe('Malformed JSON payload', () => {
+    const malformedJsonEndpoints = [
+      [
+        'single create movement',
+        'POST',
+        `/movements/${wasteTrackingId}/receive`
+      ],
+      [
+        'single update movement',
+        'PUT',
+        `/movements/${wasteTrackingId}/receive`
+      ],
+      ['retry audit log', 'POST', '/movements/retry-audit-log'],
+      ['bulk create movements', 'POST', '/bulk/bulk-id/movements/receive'],
+      ['bulk update movements', 'PUT', '/bulk/bulk-id/movements/receive'],
+      ['production approval tests', 'POST', '/production-approval-tests']
+    ]
+
+    test.each(malformedJsonEndpoints)(
+      'should return 400 for structurally malformed JSON on the %s endpoint',
+      async (_name, method, url) => {
+        const response = await server.inject({
+          method,
+          url,
+          payload: '{"receiver" "value"}',
+          headers: {
+            'content-type': 'application/json',
+            authorization:
+              'Basic d2FzdGUtbW92ZW1lbnQtZXh0ZXJuYWwtYXBpOjRkNWQ0OGNiLTQ1NmEtNDcwYS04ODE0LWVhZTI3NThiZTkwZA=='
+          }
+        })
+
+        expect(response.statusCode).toBe(400)
+        expect(response.result).toEqual({
+          validation: {
+            errors: [
+              {
+                key: 'payload',
+                errorType: 'InvalidFormat',
+                message: 'Invalid request payload JSON format'
+              }
+            ]
+          }
+        })
+      }
+    )
+
+    test('should return 400 for an invalid JSON escape sequence', async () => {
+      const response = await server.inject({
+        method: 'POST',
+        url: `/movements/${wasteTrackingId}/receive`,
+        payload: '{"receiver":{"authorisationNumber":"po9099ci\\D12345"}}',
+        headers: {
+          'content-type': 'application/json',
+          authorization:
+            'Basic d2FzdGUtbW92ZW1lbnQtZXh0ZXJuYWwtYXBpOjRkNWQ0OGNiLTQ1NmEtNDcwYS04ODE0LWVhZTI3NThiZTkwZA=='
+        }
+      })
+
+      expect(response.statusCode).toBe(400)
+      expect(response.result.validation.errors[0].errorType).toBe(
+        'InvalidFormat'
+      )
+    })
+  })
+
   describe('Granular Error Categories', () => {
     test('should return InvalidType for wrong data type (string where number expected)', async () => {
       const basePayload = createBulkMovementRequest()


### PR DESCRIPTION
### Description
Ticket [DWTA-374](https://eaflood.atlassian.net/browse/DWTA-374)

- Added a new utility function `formatPayloadParseError` to provide consistent error handling for 400 errors caused by invalid JSON payloads.
- Updated existing logic in `error-handler.js` to properly distinguish between general errors and payload parsing issues.
- Introduced related unit tests to confirm accurate error handling for endpoints receiving malformed JSON data.

[DWTA-374]: https://eaflood.atlassian.net/browse/DWTA-374?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ